### PR TITLE
Added link to Sugata's DLSG files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+data.galaxyzoo.org
+====================
+
+To run locally, first make sure the repo files are updated. Then run the command:
+
+    python -m SimpleHTTPServer 8000
+
+Then open the following in the browser to view the page:
+
+    localhost:8000
+
+Other static file servers can also be run in the root directory if you prefer. 

--- a/index.html
+++ b/index.html
@@ -31,12 +31,13 @@
 		    			<ul class="sub-nav">
 		    				<li><a data-scroll-nav="5">Full Catalog</a></li>
 		    				<li><a data-scroll-nav="6">Bar Lengths</a></li>
+		    				<li><a data-scroll-nav="7">Dust-Lane Spheroidal Galaxies</a></li>
 		    			</ul>
 		    		</li>
 		    		<li>
-		    			<a data-scroll-nav="7">Galaxy Zoo: Hubble</a>
+		    			<a data-scroll-nav="8">Galaxy Zoo: Hubble</a>
 		    			<ul class="sub-nav">
-		    				<li><a data-scroll-nav="8">Bar Fraction Evolution</a></li>
+		    				<li><a data-scroll-nav="9">Bar Fraction Evolution</a></li>
 		    			</ul>
 		    		</li>
 		    	</ul>
@@ -289,7 +290,7 @@
 					<div data-scroll-index="5">
 						<h2>Full Catalog</h2>
                         <p>These tables provide the GZ2 classifications for nearly 300,000 galaxies in the SDSS.
-						<p>The project description and data reduction is in <a href="http://arxiv.org/abs/1308.3496v2">Willett et al. (2013; accepted to MNRAS)</a> &mdash; please cite this paper if making any use of the GZ2 data. The table numbers below are the same as their order in the paper.</p>
+						<p>The project description and data reduction is in <a href="http://arxiv.org/abs/1308.3496v2">Willett et al. (2013)</a> &mdash; please cite this paper if making any use of the GZ2 data. The table numbers below are the same as their order in the paper.</p>
 
 						<br />	
 
@@ -443,11 +444,24 @@
 					</div>
 
 					<div data-scroll-index="7">
+						<h2>Dust-lane spheroidal galaxies</h2>
+						<p>Early Galaxy Zoo 2 classifications were used to identify a sample of 362 spheroidal galaxies with prominent dust lanes (DLSGs), ranging from redshifts of z=0.01 to 0.07. Catalogues of the galaxy properties, along with multi-wavelength coverage from radio through ultraviolet, are available at The Dataverse Network.</p>
+                        
+                        <ul>
+                            <li><a href="http://thedata.harvard.edu/dvn/dv/dustlanes">Dust-lane spheroids (ASCII)</a>
+                        </ul>
+
+                        <p>Please cite the DLSG (<a href="http://adsabs.harvard.edu/cgi-bin/bib_query?arXiv:1107.5306">Kaviraj et al. 2012</a>; <a href="http://adsabs.harvard.edu/cgi-bin/bib_query?arXiv:1107.5310">Shabala et al. 2012</a>; <a href="http://adsabs.harvard.edu/doi/10.1093/mnras/stt1629">Kaviraj et al. 2013</a>) and Galaxy Zoo 2 (<a href="http://arxiv.org/abs/1308.3496v2">Willett et al. 2013</a>) publications if using this data.</p>
+                        
+						<br />
+					</div>
+
+					<div data-scroll-index="8">
 						<h1>Galaxy Zoo: Hubble</h1>
 						<p><a href="http://hubble.galaxyzoo.org">Galaxy Zoo: Hubble</a> used data from the Hubble Space Telescope to classify images of galaxies at higher redshifts. Images were taken from the Advanced Camera for Surveys (ACS) aboard Hubble, comprising data from the GEMS, GOODS-N, and AEGIS surveys. Full data reduction and analysis of GZ: Hubble results are ongoing.</p>
 					</div>
 
-					<div data-scroll-index="8">
+					<div data-scroll-index="9">
 						<h2>Bar fraction evolution</h2>
 						<p>In Melvin et al. (2013, submitted), we use GZ2 and GZ: Hubble data to study the evolution of the bar fraction in galaxies over cosmic timescales. Presented here are links to webpages with the HST postage stamp images for the different galaxy samples from Melvin et al.</p>
 


### PR DESCRIPTION
Files currently live at Harvard's Dataverse site in ASCII format; Sugata requests only a link to the page for now, since his colleague is in charge of maintaining the files. Might be good to copy them to AWS with the other catalogues once he approves a final form. 
