### PR TITLE
Added Table 10 "Normal-depth sample with new debiasing method" 

### DIFF
--- a/public/data/gz2/gz2_hart16.txt
+++ b/public/data/gz2/gz2_hart16.txt
@@ -1,0 +1,240 @@
+Contact:    Ross Hart (ross.hart@nottingham.ac.uk), or Steven Bamford (steven.bamford@nottingham.ac.uk) with any questions.
+Reference:  The project and data release are described in Hart et al. (2016). Please cite this paper if making use of any data in this table in publications.
+
+Description: Morphological classifications of SDSS main sample spectroscopic galaxies from Galaxy Zoo 2.
+
+This table contains all galaxies with spectroscopic redshifts classified in GZ2 (from the GZ2 normal, extra and stripe82 normal depth), and apparent r-band magnitudes <= 17.0. This gives 239,695 galaxies in total.
+
+name                                                                type        length      unit    ucd     description
+----------------------------------------------------------------------------------------------------------------------------------
+dr7objid                                                            bigint      8                           match to the DR7 objID for the corresponding normal-depth image
+ra                                                                  real        4                           right ascension [J2000.0], decimal degrees
+dec                                                                 real        4                           declination [J2000.0], decimal degrees
+rastring                                                            varchar     11                          right ascension [J2000.0], sexagesimal
+decstring                                                           varchar     11                          declination [J2000.0], sexagesimal
+sample                                                              varchar     20                          sub-sample identification
+gz2class                                                            varchar     20                          shorthand string for the most common consensus morphology
+total_classifications                                               int		4                           total number of classifications for this galaxy
+total_votes                                                         int		4                           total number of votes for each response, summed over all classifications
+t01_smooth_or_features_a01_smooth_count                             int		4                           number of votes for the "smooth" response to Task 01
+t01_smooth_or_features_a01_smooth_weight                            float		8                           consistency-weighted number of votes for the "smooth" response to Task 01
+t01_smooth_or_features_a01_smooth_fraction                          float		8                           fraction of votes for "smooth" out of all responses to Task 01
+t01_smooth_or_features_a01_smooth_weighted_fraction                 float		8                           consistency-weighted fraction of votes for "smooth" out of all responses to Task 01
+t01_smooth_or_features_a01_smooth_debiased                          float		8                           debiased fraction of votes for "smooth" out of all responses to Task 01
+t01_smooth_or_features_a01_smooth_flag                              int			4                           flag for "smooth" - 1 if galaxy is in clean sample, 0 otherwise
+t01_smooth_or_features_a02_features_or_disk_count                   int			4                           number of votes for the "features or disk" response to Task 01
+t01_smooth_or_features_a02_features_or_disk_weight                  float		8                           consistency-weighted number of votes for the "features or disk" response to Task 01
+t01_smooth_or_features_a02_features_or_disk_fraction                float		8                           fraction of votes for "features or disk" out of all responses to Task 01
+t01_smooth_or_features_a02_features_or_disk_weighted_fraction       float		8                           consistency-weighted fraction of votes for "features or disk" out of all responses to Task 01
+t01_smooth_or_features_a02_features_or_disk_debiased                float		8                           debiased fraction of votes for "features or disk" out of all responses to Task 01
+t01_smooth_or_features_a02_features_or_disk_flag                    int			4                           flag for "features or disk"  - 1 if galaxy is in clean sample, 0 otherwise
+t01_smooth_or_features_a03_star_or_artifact_count                   int			4                           number of votes for the "star or artifact" response to Task 01
+t01_smooth_or_features_a03_star_or_artifact_weight                  float		8                           consistency-weighted number of votes for the "star or artifact" response to Task 01
+t01_smooth_or_features_a03_star_or_artifact_fraction                float		8                           fraction of votes for "star or artifact" out of all responses to Task 01
+t01_smooth_or_features_a03_star_or_artifact_weighted_fraction       float		8                           consistency-weighted fraction of votes for "star or artifact" out of all responses to Task 01
+t01_smooth_or_features_a03_star_or_artifact_debiased                float		8                           debiased fraction of votes for "star or artifact" out of all responses to Task 01
+t01_smooth_or_features_a03_star_or_artifact_flag                    int			4                           flag for "star or artifact"  - 1 if galaxy is in clean sample, 0 otherwise
+t02_edgeon_a04_yes_count                                            int			4                           number of votes for the "edge-on" response to Task 02
+t02_edgeon_a04_yes_weight                                           float		8                           consistency-weighted number of votes for the "edge-on" response to Task 02
+t02_edgeon_a04_yes_fraction                                         float		8                           fraction of votes for "edge-on" out of all responses to Task 02
+t02_edgeon_a04_yes_weighted_fraction                                float		8                           consistency-weighted fraction of votes for "edge-on" out of all responses to Task 02
+t02_edgeon_a04_yes_debiased                                         float		8                           debiased fraction of votes for "edge-on" out of all responses to Task 02
+t02_edgeon_a04_yes_flag                                             int			4                           flag for "edge-on"  - 1 if galaxy is in clean sample, 0 otherwise
+t02_edgeon_a05_no_count                                             int			4                           number of votes for the "not edge-on" response to Task 02
+t02_edgeon_a05_no_weight                                            float		8                           consistency-weighted number of votes for the "not edge-on" response to Task 02
+t02_edgeon_a05_no_fraction                                          float		8                           fraction of votes for "not edge-on" out of all responses to Task 02
+t02_edgeon_a05_no_weighted_fraction                                 float		8                           consistency-weighted fraction of votes for "not edge-on" out of all responses to Task 02
+t02_edgeon_a05_no_debiased                                          float		8                           debiased fraction of votes for "not edge-on" out of all responses to Task 02
+t02_edgeon_a05_no_flag                                              int			4                           flag for "not edge-on"  - 1 if galaxy is in clean sample, 0 otherwise
+t03_bar_a06_bar_count                                               int			4                           number of votes for the "bar" response to Task 03
+t03_bar_a06_bar_weight                                              float		8                           consistency-weighted number of votes for the "bar" response to Task 03
+t03_bar_a06_bar_fraction                                            float		8                           fraction of votes for "bar" out of all responses to Task 03
+t03_bar_a06_bar_weighted_fraction                                   float		8                           consistency-weighted fraction of votes for "bar" out of all responses to Task 03
+t03_bar_a06_bar_debiased                                            float		8                           debiased fraction of votes for "bar" out of all responses to Task 03
+t03_bar_a06_bar_flag                                                int			4                           flag for "bar"  - 1 if galaxy is in clean sample, 0 otherwise
+t03_bar_a07_no_bar_count                                            int			4                           number of votes for the "no bar" response to Task 03
+t03_bar_a07_no_bar_weight                                           float		8                           consistency-weighted number of votes for the "no bar" response to Task 03
+t03_bar_a07_no_bar_fraction                                         float		8                           fraction of votes for "no bar" out of all responses to Task 03
+t03_bar_a07_no_bar_weighted_fraction                                float		8                           consistency-weighted fraction of votes for "no bar" out of all responses to Task 03
+t03_bar_a07_no_bar_debiased                                         float		8                           debiased fraction of votes for "no bar" out of all responses to Task 03
+t03_bar_a07_no_bar_flag                                             int			4                           flag for "no bar"  - 1 if galaxy is in clean sample, 0 otherwise
+t04_spiral_a08_spiral_count                                         int			4                           number of votes for the "spiral structure" response to Task 04
+t04_spiral_a08_spiral_weight                                        float		8                           consistency-weighted number of votes for the "spiral structure" response to Task 04
+t04_spiral_a08_spiral_fraction                                      float		8                           fraction of votes for "spiral structure" out of all responses to Task 04
+t04_spiral_a08_spiral_weighted_fraction                             float		8                           consistency-weighted fraction of votes for "spiral structure" out of all responses to Task 04
+t04_spiral_a08_spiral_debiased                                      float		8                           debiased fraction of votes for "spiral structure" out of all responses to Task 04
+t04_spiral_a08_spiral_flag                                          int			4                           flag for "spiral structure"  - 1 if galaxy is in clean sample, 0 otherwise
+t04_spiral_a09_no_spiral_count                                      int			4                           number of votes for the "no spiral structure" response to Task 04
+t04_spiral_a09_no_spiral_weight                                     float		8                           consistency-weighted number of votes for the "no spiral structure" response to Task 04
+t04_spiral_a09_no_spiral_fraction                                   float		8                           fraction of votes for "no spiral structure" out of all responses to Task 04
+t04_spiral_a09_no_spiral_weighted_fraction                          float		8                           consistency-weighted fraction of votes for "no spiral structure" out of all responses to Task 04
+t04_spiral_a09_no_spiral_debiased                                   float		8                           debiased fraction of votes for "no spiral structure" out of all responses to Task 04
+t04_spiral_a09_no_spiral_flag                                       int			4                           flag for "no spiral structure"  - 1 if galaxy is in clean sample, 0 otherwise
+t05_bulge_prominence_a10_no_bulge_count                             int			4                           number of votes for the "no bulge" response to Task 05
+t05_bulge_prominence_a10_no_bulge_weight                            float		8                           consistency-weighted number of votes for the "no bulge" response to Task 05
+t05_bulge_prominence_a10_no_bulge_fraction                          float		8                           fraction of votes for "no bulge" out of all responses to Task 05
+t05_bulge_prominence_a10_no_bulge_weighted_fraction                 float		8                           consistency-weighted fraction of votes for "no bulge" out of all responses to Task 05
+t05_bulge_prominence_a10_no_bulge_debiased                          float		8                           debiased fraction of votes for "no bulge" out of all responses to Task 05
+t05_bulge_prominence_a10_no_bulge_flag                              int			4                           flag for "no bulge"  - 1 if galaxy is in clean sample, 0 otherwise
+t05_bulge_prominence_a11_just_noticeable_count                      int			4                           number of votes for the "just noticeable bulge" response to Task 05
+t05_bulge_prominence_a11_just_noticeable_weight                     float		8                           consistency-weighted number of votes for the "just noticeable bulge" response to Task 05
+t05_bulge_prominence_a11_just_noticeable_fraction                   float		8                           fraction of votes for "just noticeable bulge" out of all responses to Task 05
+t05_bulge_prominence_a11_just_noticeable_weighted_fraction          float		8                           consistency-weighted fraction of votes for "just noticeable bulge" out of all responses to Task 05
+t05_bulge_prominence_a11_just_noticeable_debiased                   float		8                           debiased fraction of votes for "just noticeable bulge" out of all responses to Task 05
+t05_bulge_prominence_a11_just_noticeable_flag                       int			4                           flag for "just noticeable bulge"  - 1 if galaxy is in clean sample, 0 otherwise
+t05_bulge_prominence_a12_obvious_count                              int			4                           number of votes for the "obvious bulge" response to Task 05
+t05_bulge_prominence_a12_obvious_weight                             float		8                           consistency-weighted number of votes for the "obvious bulge" response to Task 05
+t05_bulge_prominence_a12_obvious_fraction                           float		8                           fraction of votes for "obvious bulge" out of all responses to Task 05
+t05_bulge_prominence_a12_obvious_weighted_fraction                  float		8                           consistency-weighted fraction of votes for "obvious bulge" out of all responses to Task 05
+t05_bulge_prominence_a12_obvious_debiased                           float		8                           debiased fraction of votes for "obvious bulge" out of all responses to Task 05
+t05_bulge_prominence_a12_obvious_flag                               int			4                           flag for "obvious bulge"  - 1 if galaxy is in clean sample, 0 otherwise
+t05_bulge_prominence_a13_dominant_count                             int			4                           number of votes for the "dominant bulge" response to Task 05
+t05_bulge_prominence_a13_dominant_weight                            float		8                           consistency-weighted number of votes for the "dominant bulge" response to Task 05
+t05_bulge_prominence_a13_dominant_fraction                          float		8                           fraction of votes for "dominant bulge" out of all responses to Task 05
+t05_bulge_prominence_a13_dominant_weighted_fraction                 float		8                           consistency-weighted fraction of votes for "dominant bulge" out of all responses to Task 05
+t05_bulge_prominence_a13_dominant_debiased                          float		8                           debiased fraction of votes for "dominant bulge" out of all responses to Task 05
+t05_bulge_prominence_a13_dominant_flag                              int			4                           flag for "dominant bulge"  - 1 if galaxy is in clean sample, 0 otherwise
+t06_odd_a14_yes_count                                               int			4                           number of votes for the "something odd" response to Task 06
+t06_odd_a14_yes_weight                                              float		8                           consistency-weighted number of votes for the "something odd" response to Task 06
+t06_odd_a14_yes_fraction                                            float		8                           fraction of votes for "something odd" out of all responses to Task 06
+t06_odd_a14_yes_weighted_fraction                                   float		8                           consistency-weighted fraction of votes for "something odd" out of all responses to Task 06
+t06_odd_a14_yes_debiased                                            float		8                           debiased fraction of votes for "something odd" out of all responses to Task 06
+t06_odd_a14_yes_flag                                                int			4                           flag for "something odd"  - 1 if galaxy is in clean sample, 0 otherwise
+t06_odd_a15_no_count                                                int			4                           number of votes for the "nothing odd" response to Task 06
+t06_odd_a15_no_weight                                               float		8                           consistency-weighted number of votes for the "nothing odd" response to Task 06
+t06_odd_a15_no_fraction                                             float		8                           fraction of votes for "nothing odd" out of all responses to Task 06
+t06_odd_a15_no_weighted_fraction                                    float		8                           consistency-weighted fraction of votes for "nothing odd" out of all responses to Task 06
+t06_odd_a15_no_debiased                                             float		8                           debiased fraction of votes for "nothing odd" out of all responses to Task 06
+t06_odd_a15_no_flag                                                 int			4                           flag for "nothing odd"  - 1 if galaxy is in clean sample, 0 otherwise
+t07_rounded_a16_completely_round_count                              int			4                           number of votes for the "smooth and completely round" response to Task 07
+t07_rounded_a16_completely_round_weight                             float		8                           consistency-weighted number of votes for the "smooth and completely round" response to Task 07
+t07_rounded_a16_completely_round_fraction                           float		8                           fraction of votes for "smooth and completely round" out of all responses to Task 07
+t07_rounded_a16_completely_round_weighted_fraction                  float		8                           consistency-weighted fraction of votes for "smooth and completely round" out of all responses to Task 07
+t07_rounded_a16_completely_round_debiased                           float		8                           debiased fraction of votes for "smooth and completely round" out of all responses to Task 07
+t07_rounded_a16_completely_round_flag                               int			4                           flag for "smooth and completely round"  - 1 if galaxy is in clean sample, 0 otherwise
+t07_rounded_a17_in_between_count                                    int			4                           number of votes for the "smooth and in-between roundness" response to Task 07
+t07_rounded_a17_in_between_weight                                   float		8                           consistency-weighted number of votes for the "smooth and in-between roundness" response to Task 07
+t07_rounded_a17_in_between_fraction                                 float		8                           fraction of votes for "smooth and in-between roundness" out of all responses to Task 07
+t07_rounded_a17_in_between_weighted_fraction                        float		8                           consistency-weighted fraction of votes for "smooth and in-between roundness" out of all responses to Task 07
+t07_rounded_a17_in_between_debiased                                 float		8                           debiased fraction of votes for "smooth and in-between roundness" out of all responses to Task 07
+t07_rounded_a17_in_between_flag                                     int			4                           flag for "smooth and in-between roundness"  - 1 if galaxy is in clean sample, 0 otherwise
+t07_rounded_a18_cigar_shaped_count                                  int			4                           number of votes for the "smooth and cigar-shaped" response to Task 07
+t07_rounded_a18_cigar_shaped_weight                                 float		8                           consistency-weighted number of votes for the "smooth and cigar-shaped" response to Task 07
+t07_rounded_a18_cigar_shaped_fraction                               float		8                           fraction of votes for "smooth and cigar-shaped" out of all responses to Task 07
+t07_rounded_a18_cigar_shaped_weighted_fraction                      float		8                           consistency-weighted fraction of votes for "smooth and cigar-shaped" out of all responses to Task 07
+t07_rounded_a18_cigar_shaped_debiased                               float		8                           debiased fraction of votes for "smooth and cigar-shaped" out of all responses to Task 07
+t07_rounded_a18_cigar_shaped_flag                                   int			4                           flag for "smooth and cigar-shaped"  - 1 if galaxy is in clean sample, 0 otherwise
+t08_odd_feature_a19_ring_count                                      int			4                           number of votes for the "odd feature is a ring" response to Task 08
+t08_odd_feature_a19_ring_weight                                     float		8                           consistency-weighted number of votes for the "odd feature is a ring" response to Task 08
+t08_odd_feature_a19_ring_fraction                                   float		8                           fraction of votes for "odd feature is a ring" out of all responses to Task 08
+t08_odd_feature_a19_ring_weighted_fraction                          float		8                           consistency-weighted fraction of votes for "odd feature is a ring" out of all responses to Task 08
+t08_odd_feature_a19_ring_debiased                                   float		8                           debiased fraction of votes for "odd feature is a ring" out of all responses to Task 08
+t08_odd_feature_a19_ring_flag                                       int			4                           flag for "odd feature is a ring"  - 1 if galaxy is in clean sample, 0 otherwise
+t08_odd_feature_a20_lens_or_arc_count                               int			4                           number of votes for the "odd feature is a lens or arc" response to Task 08
+t08_odd_feature_a20_lens_or_arc_weight                              float		8                           consistency-weighted number of votes for the "odd feature is a lens or arc" response to Task 08
+t08_odd_feature_a20_lens_or_arc_fraction                            float		8                           fraction of votes for "odd feature is a lens or arc" out of all responses to Task 08
+t08_odd_feature_a20_lens_or_arc_weighted_fraction                   float		8                           consistency-weighted fraction of votes for "odd feature is a lens or arc" out of all responses to Task 08
+t08_odd_feature_a20_lens_or_arc_debiased                            float		8                           debiased fraction of votes for "odd feature is a lens or arc" out of all responses to Task 08
+t08_odd_feature_a20_lens_or_arc_flag                                int			4                           flag for "odd feature is a lens or arc"  - 1 if galaxy is in clean sample, 0 otherwise
+t08_odd_feature_a21_disturbed_count                                 int			4                           number of votes for the "odd feature is a disturbed" galaxy response to Task 08
+t08_odd_feature_a21_disturbed_weight                                float		8                           consistency-weighted number of votes for the "odd feature is a disturbed galaxy response to Task 08
+t08_odd_feature_a21_disturbed_fraction                              float		8                           fraction of votes for "odd feature is a disturbed" galaxy out of all responses to Task 08
+t08_odd_feature_a21_disturbed_weighted_fraction                     float		8                           consistency-weighted fraction of votes for "odd feature is a disturbed galaxy out of all responses to Task 08
+t08_odd_feature_a21_disturbed_debiased                              float		8                           debiased fraction of votes for "odd feature is a disturbed" galaxy out of all responses to Task 08
+t08_odd_feature_a21_disturbed_flag                                  int			4                           flag for "odd feature is a disturbed galaxy"  - 1 if galaxy is in clean sample, 0 otherwise
+t08_odd_feature_a22_irregular_count                                 int			4                           number of votes for the "odd feature is an irregular" galaxy response to Task 08
+t08_odd_feature_a22_irregular_weight                                float		8                           consistency-weighted number of votes for the "odd feature is an irregular galaxy response to Task 08
+t08_odd_feature_a22_irregular_fraction                              float		8                           fraction of votes for "odd feature is an irregular" galaxy out of all responses to Task 08
+t08_odd_feature_a22_irregular_weighted_fraction                     float		8                           consistency-weighted fraction of votes for "odd feature is an irregular galaxy out of all responses to Task 08
+t08_odd_feature_a22_irregular_debiased                              float		8                           debiased fraction of votes for "odd feature is an irregular" galaxy out of all responses to Task 08
+t08_odd_feature_a22_irregular_flag                                  int			4                           flag for "odd feature is an irregular galaxy"  - 1 if galaxy is in clean sample, 0 otherwise
+t08_odd_feature_a23_other_count                                     int			4                           number of votes for the "odd feature is something else" response to Task 08
+t08_odd_feature_a23_other_weight                                    float		8                           consistency-weighted number of votes for the "odd feature is something else" response to Task 08
+t08_odd_feature_a23_other_fraction                                  float		8                           fraction of votes for "odd feature is something else" out of all responses to Task 08
+t08_odd_feature_a23_other_weighted_fraction                         float		8                           consistency-weighted fraction of votes for "odd feature is something else" out of all responses to Task 08
+t08_odd_feature_a23_other_debiased                                  float		8                           debiased fraction of votes for "odd feature is something else" out of all responses to Task 08
+t08_odd_feature_a23_other_flag                                      int			4                           flag for "odd feature is something else"  - 1 if galaxy is in clean sample, 0 otherwise
+t08_odd_feature_a24_merger_count                                    int			4                           number of votes for the "odd feature is a merger" response to Task 08
+t08_odd_feature_a24_merger_weight                                   float		8                           consistency-weighted number of votes for the "odd feature is a merger" response to Task 08
+t08_odd_feature_a24_merger_fraction                                 float		8                           fraction of votes for "odd feature is a merger" out of all responses to Task 08
+t08_odd_feature_a24_merger_weighted_fraction                        float		8                           consistency-weighted fraction of votes for "odd feature is a merger" out of all responses to Task 08
+t08_odd_feature_a24_merger_debiased                                 float		8                           debiased fraction of votes for "odd feature is a merger" out of all responses to Task 08
+t08_odd_feature_a24_merger_flag                                     int			4                           flag for "odd feature is a merger"  - 1 if galaxy is in clean sample, 0 otherwise
+t08_odd_feature_a38_dust_lane_count                                 int			4                           number of votes for the "odd feature is a dust lane" response to Task 08
+t08_odd_feature_a38_dust_lane_weight                                float		8                           consistency-weighted number of votes for the "odd feature is a dust lane" response to Task 08
+t08_odd_feature_a38_dust_lane_fraction                              float		8                           fraction of votes for "odd feature is a dust lane" out of all responses to Task 08
+t08_odd_feature_a38_dust_lane_weighted_fraction                     float		8                           consistency-weighted fraction of votes for "odd feature is a dust lane" out of all responses to Task 08
+t08_odd_feature_a38_dust_lane_debiased                              float		8                           debiased fraction of votes for "odd feature is a dust lane" out of all responses to Task 08
+t08_odd_feature_a38_dust_lane_flag                                  int			4                           flag for "odd feature is a dust lane"  - 1 if galaxy is in clean sample, 0 otherwise
+t09_bulge_shape_a25_rounded_count                                   int			4                           number of votes for the "edge-on bulge is rounded" response to Task 09
+t09_bulge_shape_a25_rounded_weight                                  float		8                           consistency-weighted number of votes for the "edge-on bulge is rounded" response to Task 09
+t09_bulge_shape_a25_rounded_fraction                                float		8                           fraction of votes for "edge-on bulge is rounded" out of all responses to Task 09
+t09_bulge_shape_a25_rounded_weighted_fraction                       float		8                           consistency-weighted fraction of votes for "edge-on bulge is rounded" out of all responses to Task 09
+t09_bulge_shape_a25_rounded_debiased                                float		8                           debiased fraction of votes for "edge-on bulge is rounded" out of all responses to Task 09
+t09_bulge_shape_a25_rounded_flag                                    int			4                           flag for "edge-on bulge is rounded"  - 1 if galaxy is in clean sample, 0 otherwise
+t09_bulge_shape_a26_boxy_count                                      int			4                           number of votes for the "edge-on bulge is boxy" response to Task 09
+t09_bulge_shape_a26_boxy_weight                                     float		8                           consistency-weighted number of votes for the "edge-on bulge is boxy" response to Task 09
+t09_bulge_shape_a26_boxy_fraction                                   float		8                           fraction of votes for "edge-on bulge is boxy" out of all responses to Task 09
+t09_bulge_shape_a26_boxy_weighted_fraction                          float		8                           consistency-weighted fraction of votes for "edge-on bulge is boxy" out of all responses to Task 09
+t09_bulge_shape_a26_boxy_debiased                                   float		8                           debiased fraction of votes for "edge-on bulge is boxy" out of all responses to Task 09
+t09_bulge_shape_a26_boxy_flag                                       int			4                           flag for "edge-on bulge is boxy"  - 1 if galaxy is in clean sample, 0 otherwise
+t09_bulge_shape_a27_no_bulge_count                                  int			4                           number of votes for the "no edge-on bulge" response to Task 09
+t09_bulge_shape_a27_no_bulge_weight                                 float		8                           consistency-weighted number of votes for the "no edge-on bulge" response to Task 09
+t09_bulge_shape_a27_no_bulge_fraction                               float		8                           fraction of votes for "no edge-on bulge" out of all responses to Task 09
+t09_bulge_shape_a27_no_bulge_weighted_fraction                      float		8                           consistency-weighted fraction of votes for "no edge-on bulge" out of all responses to Task 09
+t09_bulge_shape_a27_no_bulge_debiased                               float		8                           debiased fraction of votes for "no edge-on bulge" out of all responses to Task 09
+t09_bulge_shape_a27_no_bulge_flag                                   int			4                           flag for "no edge-on bulge"  - 1 if galaxy is in clean sample, 0 otherwise
+t10_arms_winding_a28_tight_count                                    int			4                           number of votes for the "tightly wound spiral arms" response to Task 10
+t10_arms_winding_a28_tight_weight                                   float		8                           consistency-weighted number of votes for the "tightly wound spiral arms" response to Task 10
+t10_arms_winding_a28_tight_fraction                                 float		8                           fraction of votes for "tightly wound spiral arms" out of all responses to Task 10
+t10_arms_winding_a28_tight_weighted_fraction                        float		8                           consistency-weighted fraction of votes for "tightly wound spiral arms" out of all responses to Task 10
+t10_arms_winding_a28_tight_debiased                                 float		8                           debiased fraction of votes for "tightly wound spiral arms" out of all responses to Task 10
+t10_arms_winding_a28_tight_flag                                     int			4                           flag for "tightly wound spiral arms"  - 1 if galaxy is in clean sample, 0 otherwise
+t10_arms_winding_a29_medium_count                                   int			4                           number of votes for the "medium wound spiral arms" response to Task 10
+t10_arms_winding_a29_medium_weight                                  float		8                           consistency-weighted number of votes for the "medium wound spiral arms" response to Task 10
+t10_arms_winding_a29_medium_fraction                                float		8                           fraction of votes for "medium wound spiral arms" out of all responses to Task 10
+t10_arms_winding_a29_medium_weighted_fraction                       float		8                           consistency-weighted fraction of votes for "medium wound spiral arms" out of all responses to Task 10
+t10_arms_winding_a29_medium_debiased                                float		8                           debiased fraction of votes for "medium wound spiral arms" out of all responses to Task 10
+t10_arms_winding_a29_medium_flag                                    int			4                           flag for "medium wound spiral arms"  - 1 if galaxy is in clean sample, 0 otherwise
+t10_arms_winding_a30_loose_count                                    int			4                           number of votes for the "loosely wound spiral arms" response to Task 10
+t10_arms_winding_a30_loose_weight                                   float		8                           consistency-weighted number of votes for the "loosely wound spiral arms" response to Task 10
+t10_arms_winding_a30_loose_fraction                                 float		8                           fraction of votes for "loosely wound spiral arms" out of all responses to Task 10
+t10_arms_winding_a30_loose_weighted_fraction                        float		8                           consistency-weighted fraction of votes for "loosely wound spiral arms" out of all responses to Task 10
+t10_arms_winding_a30_loose_debiased                                 float		8                           debiased fraction of votes for "loosely wound spiral arms" out of all responses to Task 10
+t10_arms_winding_a30_loose_flag                                     int			4                           flag for "loosely wound spiral arms"  - 1 if galaxy is in clean sample, 0 otherwise
+t11_arms_number_a31_1_count                                         int			4                           number of votes for the "1 spiral arm" response to Task 11
+t11_arms_number_a31_1_weight                                        float		8                           consistency-weighted number of votes for the "1 spiral arm" response to Task 11
+t11_arms_number_a31_1_fraction                                      float		8                           fraction of votes for "1 spiral arm" out of all responses to Task 11
+t11_arms_number_a31_1_weighted_fraction                             float		8                           consistency-weighted fraction of votes for "1 spiral arm" out of all responses to Task 11
+t11_arms_number_a31_1_debiased                                      float		8                           debiased fraction of votes for "1 spiral arm" out of all responses to Task 11
+t11_arms_number_a31_1_flag                                          int			4                           flag for "1 spiral arm"  - 1 if galaxy is in clean sample, 0 otherwise
+t11_arms_number_a32_2_count                                         int			4                           number of votes for the "2 spiral arms" response to Task 11
+t11_arms_number_a32_2_weight                                        float		8                           consistency-weighted number of votes for the "2 spiral arms" response to Task 11
+t11_arms_number_a32_2_fraction                                      float		8                           fraction of votes for "2 spiral arms" out of all responses to Task 11
+t11_arms_number_a32_2_weighted_fraction                             float		8                           consistency-weighted fraction of votes for "2 spiral arms" out of all responses to Task 11
+t11_arms_number_a32_2_debiased                                      float		8                           debiased fraction of votes for "2 spiral arms" out of all responses to Task 11
+t11_arms_number_a32_2_flag                                          int			4                           flag for "2 spiral arms"  - 1 if galaxy is in clean sample, 0 otherwise
+t11_arms_number_a33_3_count                                         int			4                           number of votes for the "3 spiral arms" response to Task 11
+t11_arms_number_a33_3_weight                                        float		8                           consistency-weighted number of votes for the "3 spiral arms" response to Task 11
+t11_arms_number_a33_3_fraction                                      float		8                           fraction of votes for "3 spiral arms" out of all responses to Task 11
+t11_arms_number_a33_3_weighted_fraction                             float		8                           consistency-weighted fraction of votes for "3 spiral arms" out of all responses to Task 11
+t11_arms_number_a33_3_debiased                                      float		8                           debiased fraction of votes for "3 spiral arms" out of all responses to Task 11
+t11_arms_number_a33_3_flag                                          int			4                           flag for "3 spiral arms"  - 1 if galaxy is in clean sample, 0 otherwise
+t11_arms_number_a34_4_count                                         int			4                           number of votes for the "4 spiral arms" response to Task 11
+t11_arms_number_a34_4_weight                                        float		8                           consistency-weighted number of votes for the "4 spiral arms" response to Task 11
+t11_arms_number_a34_4_fraction                                      float		8                           fraction of votes for "4 spiral arms" out of all responses to Task 11
+t11_arms_number_a34_4_weighted_fraction                             float		8                           consistency-weighted fraction of votes for "4 spiral arms" out of all responses to Task 11
+t11_arms_number_a34_4_debiased                                      float		8                           debiased fraction of votes for "4 spiral arms" out of all responses to Task 11
+t11_arms_number_a34_4_flag                                          int			4                           flag for "4 spiral arms"  - 1 if galaxy is in clean sample, 0 otherwise
+t11_arms_number_a36_more_than_4_count                               int			4                           number of votes for the "more than 4 spiral arms" response to Task 11
+t11_arms_number_a36_more_than_4_weight                              float		8                           consistency-weighted number of votes for the "more than 4 spiral arms" response to Task 11
+t11_arms_number_a36_more_than_4_fraction                            float		8                           fraction of votes for "more than 4 spiral arms" out of all responses to Task 11
+t11_arms_number_a36_more_than_4_weighted_fraction                   float		8                           consistency-weighted fraction of votes for "more than 4 spiral arms" out of all responses to Task 11
+t11_arms_number_a36_more_than_4_debiased                            float		8                           debiased fraction of votes for "more than 4 spiral arms" out of all responses to Task 11
+t11_arms_number_a36_more_than_4_flag                                int			4                           flag for "more than 4 spiral arms"  - 1 if galaxy is in clean sample, 0 otherwise
+t11_arms_number_a37_cant_tell_count                                 int			4                           number of votes for the "spiral arms present, but can't tell how many" response to Task 11
+t11_arms_number_a37_cant_tell_weight                                float		8                           consistency-weighted number of votes for the "spiral arms present, but can't tell how many" response to Task 11
+t11_arms_number_a37_cant_tell_fraction                              float		8                           fraction of votes for "spiral arms present, but can't tell how many" out of all responses to Task 11
+t11_arms_number_a37_cant_tell_weighted_fraction                     float		8                           consistency-weighted fraction of votes for "spiral arms present, but can't tell how many" out of all responses to Task 11
+t11_arms_number_a37_cant_tell_debiased                              float		8                           debiased fraction of votes for "spiral arms present, but can't tell how many" out of all responses to Task 11
+t11_arms_number_a37_cant_tell_flag                                  int			4                           flag for "spiral arms present, but can't tell how many"  - 1 if galaxy is in clean sample, 0 otherwise

--- a/public/index.html
+++ b/public/index.html
@@ -489,6 +489,24 @@
 							</tr>
 						</table>
 
+						<table class="downloads">
+							<tr>
+								<td colspan="2" class="banner">Table 10 - Normal-depth sample with new debiasing method</td>
+							</tr>
+						    <tr><td colspan=2>Table 10 contains all galaxies that were debiased with the method described in <a href="http://mnras.oxfordjournals.org/content/461/4/3663">Hart et al. (2016)</a>. Galaxies with spectroscopic redshifts classified in GZ2 (from the GZ2 normal, extra and stripe82 normal depth), and apparent r-band magnitudes less than 17.0 are included (239,695 galaxies in total). Please cite <a href="http://mnras.oxfordjournals.org/content/461/4/3663">Hart et al. (2016)</a> when using these classifications.</td></tr>
+						    <tr><td colspan=2><a href="http://gz2hart.s3.amazonaws.com/gz2_hart16.txt">Column description and format</a></td></tr>
+							<tr>
+								<td>CSV</td><td><a href="http://gz2hart.s3.amazonaws.com/gz2_hart16.csv.gz">http://gz2hart.s3.amazonaws.com/gz2_hart16.csv.gz</a></td>
+							</tr>
+							<tr>
+								<td>FITS</td><td><a href="http://gz2hart.s3.amazonaws.com/gz2_hart16.fits.gz">http://gz2hart.s3.amazonaws.com/gz2_hart16.fits.gz</a></td>
+							</tr>
+							<tr>	
+								<td>VOTable</td><td><a href="http://gz2hart.s3.amazonaws.com/gz2_hart16.vot.gz">http://gz2hart.s3.amazonaws.com/gz2_hart16.vot.gz</a></td>
+							</tr>
+						</table>
+						<br />
+
 						<br />
 						<table class="downloads">
 							<tr>
@@ -507,7 +525,11 @@
 							</tr>
 						</table>
 
-						<br />
+						<br />	
+
+
+
+						
                         <p> The code used to reduce GZ2 is available on GitHub &mdash; please take a look either at its <a href="http://willettk.github.io/galaxyzoo2/">webpage</a> or fork it from the <a href="https://github.com/willettk/galaxyzoo2">repository</a> if you're interested in the details.
 						<h3>CASjobs</h3>
 						<p>The GZ2 catalog is also accessible via <a href="http://skyserver.sdss3.org/CasJobs/">CasJobs</a> in Data Release 10. The table names in CasJobs are:</p>


### PR DESCRIPTION
Added a new table to the set of Galaxy Zoo 2 tables. This table contains all galaxies that were debiased with the method described in [Hart et al. (2016)](http://mnras.oxfordjournals.org/content/461/4/3663). Galaxies with spectroscopic redshifts classified in GZ2 (from the GZ2 normal, extra and stripe82 normal depth), and apparent r-band magnitudes less than 17.0 are included (239,695 galaxies in total).