### PR TITLE
Metadata fixes

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -388,7 +388,7 @@
 
 					<div data-scroll-index="7">
 						<h1>Galaxy Zoo 2</h1>
-                        <p> <a href="http://zoo2.galaxyzoo.org">Galaxy Zoo 2 (GZ2)</a> was the successor project to Galaxy Zoo. GZ2 extends the original Galaxy Zoo classifications for a subsample of the brightest and largest galaxies in the Legacy release, measuring more detailed morphological features. This includes galactic bars, spiral arm and pitch angle, bulges, edge-on galaxies, relative ellipticities, and many others. Two debiased Galaxy Zoo tables are provided, described in  <a href="http://arxiv.org/abs/1308.3496v2">Willett et al. (2013) </a> and <a href="http://mnras.oxfordjournals.org/content/461/4/3663">Hart et al. (2016)</a>: we strongly advise the use of the  <a href="http://mnras.oxfordjournals.org/content/461/4/3663">Hart et al. (2016)</a> table, as this debiases the GZ2 quetion tree most consistently. 
+                        <p> <a href="http://zoo2.galaxyzoo.org">Galaxy Zoo 2 (GZ2)</a> was the successor project to Galaxy Zoo. GZ2 extends the original Galaxy Zoo classifications for a subsample of the brightest and largest galaxies in the Legacy release, measuring more detailed morphological features. This includes galactic bars, spiral arm and pitch angle, bulges, edge-on galaxies, relative ellipticities, and many others. Two debiased Galaxy Zoo tables are provided, described in <a href="http://arxiv.org/abs/1308.3496v2">Willett et al. (2013) </a> and <a href="http://mnras.oxfordjournals.org/content/461/4/3663">Hart et al. (2016)</a>: we strongly advise the use of the <a href="http://mnras.oxfordjournals.org/content/461/4/3663">Hart et al. (2016)</a> table, as this debiases the GZ2 quetion tree most consistently. 
 					</div>
 
 
@@ -596,7 +596,7 @@
 
 					<div data-scroll-index="12">
 						<h2>Full catalog</h2>
-						<p>The full reduction and analysis of GZ: Hubble has been published in Willett et al. (2016; accepted to MNRAS). Please refer to and cite this paper if using any data from the project. The full data reduction pipeline and analysis codes for GZH are available as a <a href="https://github.com/willettk/gzhubble">Github repository</a>.</p>
+						<p>The full reduction and analysis of GZ: Hubble was published in <a href="https://ui.adsabs.harvard.edu/#abs/2017MNRAS.464.4176W/abstract">Willett et al. (2017)</a> (available both from <a href="https://arxiv.org/abs/1610.03068">arXiv</a> or the <a href="https://academic.oup.com/mnras/article-abstract/464/4/4176/2527878/Galaxy-Zoo-morphological-classifications-for-120?redirectedFrom=fulltext">MNRAS journal</a>). Please cite this paper if using any data from the project. The full data reduction pipeline and analysis codes for GZH are available as an open-source <a href="https://github.com/willettk/gzhubble">Github repository</a>.</p>
 					</div>
 
 						<table class="downloads">
@@ -754,7 +754,7 @@
 					<div data-scroll-index="14">
 						<h1>Galaxy Zoo: CANDELS</h1>
 						<p>Galaxy Zoo: CANDELS classified the morphology of galaxies in images from the <a href="http://candels.ucolick.org/">Cosmic Assembly Near-infrared Deep Extragalactic Legacy Survey (CANDELS)</a>. CANDELS images were taken with both the ACS and WFC3 cameras on the Hubble Space Telescope, focusing on rest-frame optical wavelengths of galaxies at redshifts of 1 &lt; z &lt; 3. </p>
-						<p>Simmons et al. (2016; accepted to MNRAS) describes the project and data release. Please refer to and cite this paper if using any data from GZC.</p>
+						<p><a href="https://ui.adsabs.harvard.edu/#abs/2017MNRAS.464.4176W/abstract">Simmons et al. (2017)</a> (available both from <a href="https://arxiv.org/abs/1610.03070">arXiv</a> or the <a href="https://academic.oup.com/mnras/article-abstract/464/4/4420/2417365/Galaxy-Zoo-quantitative-visual-morphological?redirectedFrom=fulltext">MNRAS journal</a>) describes the project and data release. Please cite this paper if using any data from Galaxy Zoo: CANDELS.</p>
 					</div>
 
 					<div data-scroll-index="15">

--- a/public/index.html
+++ b/public/index.html
@@ -732,6 +732,35 @@
 
 						<br />
 
+						<table class="downloads">
+							<tr>
+								<td colspan="3" class="banner">Metadata</td>
+							</tr>
+						    <tr><td colspan=3>These tables contain useful metadata matched to the morphological data in Tables 4&ndash;9. This includes (where available) redshifts, magnitudes, angular sizes, automatically-measured morphological parameters, and additional flags from the parent surveys.</td></tr>
+						    <tr><td colspan=3><a href="http://zooniverse-data.s3.amazonaws.com/galaxy-zoo-hubble/galaxy-zoo-hubble-metadata.zip"><b>Single zipped file</b></a> including column descriptions and FITS tables with metadata for all GZ: Hubble images</td></tr>
+                            <tr><td></td></tr>
+							<tr>
+								<td>GZH main sample</td><td><a href="http://zooniverse-data.s3.amazonaws.com/galaxy-zoo-hubble/metadata/csv/metadata_main.csv">CSV</a></td><td><a href="http://zooniverse-data.s3.amazonaws.com/galaxy-zoo-hubble/metadata/fits/metadata_main.fits">FITS</a></td>
+							</tr>
+							<tr>
+								<td>GZH GOODS, shallow-depth imaging</td><td><a href="http://zooniverse-data.s3.amazonaws.com/galaxy-zoo-hubble/metadata/csv/metadata_goods_shallow.csv">CSV</a></td><td><a href="http://zooniverse-data.s3.amazonaws.com/galaxy-zoo-hubble/metadata/fits/metadata_goods_shallow.fits">FITS</a></td>
+							</tr>
+							<tr>
+								<td>GZH GOODS, full-depth imaging</td><td><a href="http://zooniverse-data.s3.amazonaws.com/galaxy-zoo-hubble/metadata/csv/metadata_goods_full.csv">CSV</a></td><td><a href="http://zooniverse-data.s3.amazonaws.com/galaxy-zoo-hubble/metadata/fits/metadata_goods_full.fits">FITS</a></td>
+							</tr>
+							<tr>
+								<td>GZH SDSS, coadded imaging</td><td><a href="http://zooniverse-data.s3.amazonaws.com/galaxy-zoo-hubble/metadata/csv/metadata_sdss_coadd.csv">CSV</a></td><td><a href="http://zooniverse-data.s3.amazonaws.com/galaxy-zoo-hubble/metadata/fits/metadata_sdss_coadd.fits">FITS</a></td>
+							</tr>
+							<tr>
+								<td>GZH SDSS, single-depth imaging</td><td><a href="http://zooniverse-data.s3.amazonaws.com/galaxy-zoo-hubble/metadata/csv/metadata_sdss_singledepth.csv">CSV</a></td><td><a href="http://zooniverse-data.s3.amazonaws.com/galaxy-zoo-hubble/metadata/fits/metadata_sdss_singledepth.fits">FITS</a></td>
+							</tr>
+							<tr>
+								<td>FERENGI-processed images</td><td><a href="http://zooniverse-data.s3.amazonaws.com/galaxy-zoo-hubble/metadata/csv/metadata_ferengi.csv">CSV</a></td><td><a href="http://zooniverse-data.s3.amazonaws.com/galaxy-zoo-hubble/metadata/fits/metadata_ferengi.fits">FITS</a></td>
+							</tr>
+						</table>
+
+						<br />
+
 					<div data-scroll-index="13">
 						<h2>Bar fraction evolution</h2>
 						<p><a href="http://arXiv.org/abs/1401.3334">Melvin et al. (2014)</a> used GZ2 and preliminary GZ: Hubble data to study the evolution of the bar fraction in galaxies over cosmic timescales. Presented here are links to webpages with the HST postage stamp images for the different galaxy samples.</p>


### PR DESCRIPTION
- Updated the GZH and GZC papers to final, published links (I think we're still waiting on Open Access from MNRAS, though @bamford has requested it)
- Add metadata tables for GZ: Hubble images

The changes will still need to be deployed (see the README) once the PR is accepted. I don't think I have the AWS keys to do that anymore. 