### PR TITLE
change AWS, arXiv links to https

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -81,7 +81,7 @@
 					<div data-scroll-index="1">
 						<h2>Full catalog</h2>
                         <p>This webpage allows anyone to download the resulting GZ classifications of nearly 900,000 galaxies in the project.
-						<p>Galaxy Zoo is described in <a href="http://adsabs.harvard.edu/abs/2008MNRAS.389.1179L">Lintott et al. 2008, MNRAS, 389, 1179</a> and the data release is described in <a href="http://adsabs.harvard.edu/abs/2011MNRAS.410..166L">Lintott et al. 2011, 410, 166</a>. Anyone making use of the data should cite at least one of these papers in any resulting publications.</p>
+						<p>Galaxy Zoo is described in <a href="https://adsabs.harvard.edu/abs/2008MNRAS.389.1179L">Lintott et al. 2008, MNRAS, 389, 1179</a> and the data release is described in <a href="https://adsabs.harvard.edu/abs/2011MNRAS.410..166L">Lintott et al. 2011, 410, 166</a>. Anyone making use of the data should cite at least one of these papers in any resulting publications.</p>
 
 						<table class="downloads">
 							<tr>
@@ -90,18 +90,18 @@
 							<tr><td colspan="2">This table gives classifications of galaxies which have spectra included in SDSS Data Release 7. The fraction of the vote in each of the six categories is given, along with debiased votes in elliptical and spiral categories and flags identifying systems as classified as spiral, elliptical or uncertain.</tr></td>
 							</tr>
 							<tr>
-								<td>CSV (gzipped)</td><td><a href="http://galaxy-zoo-1.s3.amazonaws.com/GalaxyZoo1_DR_table2.csv.gz">GalaxyZoo1_DR_table2.csv.gz</a></td>
+								<td>CSV (gzipped)</td><td><a href="https://galaxy-zoo-1.s3.amazonaws.com/GalaxyZoo1_DR_table2.csv.gz">GalaxyZoo1_DR_table2.csv.gz</a></td>
 							</tr>
 							<tr>
-								<td>CSV (zip)</td><td><a href="http://galaxy-zoo-1.s3.amazonaws.com/GalaxyZoo1_DR_table2.csv.zip">GalaxyZoo1_DR_table2.csv.zip</a></td>
+								<td>CSV (zip)</td><td><a href="https://galaxy-zoo-1.s3.amazonaws.com/GalaxyZoo1_DR_table2.csv.zip">GalaxyZoo1_DR_table2.csv.zip</a></td>
 							</tr>
 							<tr>
-								<td>FITS</td><td><a href="http://galaxy-zoo-1.s3.amazonaws.com/GalaxyZoo1_DR_table2.fits">GalaxyZoo1_DR_table2.fits</a></td>
+								<td>FITS</td><td><a href="https://galaxy-zoo-1.s3.amazonaws.com/GalaxyZoo1_DR_table2.fits">GalaxyZoo1_DR_table2.fits</a></td>
 							</tr>
 							<tr>
-								<td>VOTable</td><td><a href="http://galaxy-zoo-1.s3.amazonaws.com/GalaxyZoo1_DR_table2.vot.gz">GalaxyZoo1_DR_table2.vot.gz</a></td>
+								<td>VOTable</td><td><a href="https://galaxy-zoo-1.s3.amazonaws.com/GalaxyZoo1_DR_table2.vot.gz">GalaxyZoo1_DR_table2.vot.gz</a></td>
 							</tr>
-						    <tr><td colspan="2"><i>Note: the provided flags in Table 2 are there for the convenience of users who do not want to get into the details too much. These are based upon a vote fraction threshold of 0.8. However, there is a complication in the debiasing (described in <a href="http://adsabs.harvard.edu/abs/2009MNRAS.393.1324B">Bamford et al. 2009</a>). The classification bias depends on whether one uses the type likelihoods directly, or applies a threshold. The bias is worse if thresholds are used. We therefore applied bias corrections computed in consistent fashion. So, for the debiased type likelihoods we computed the bias correction based on the elliptical/spiral ratio using the likelihoods directly; for the type flags we debiased the raw type likelihoods using a correction based on the elliptical/spiral ratio determined after applying a 0.8 threshold, and then applied the same threshold to produce the flags. Therefore, the type flags do not correspond to simply applying a 0.8 threshold on the debiased type likelihoods, though for many galaxies these will agree.</i></tr></td>
+						    <tr><td colspan="2"><i>Note: the provided flags in Table 2 are there for the convenience of users who do not want to get into the details too much. These are based upon a vote fraction threshold of 0.8. However, there is a complication in the debiasing (described in <a href="https://adsabs.harvard.edu/abs/2009MNRAS.393.1324B">Bamford et al. 2009</a>). The classification bias depends on whether one uses the type likelihoods directly, or applies a threshold. The bias is worse if thresholds are used. We therefore applied bias corrections computed in consistent fashion. So, for the debiased type likelihoods we computed the bias correction based on the elliptical/spiral ratio using the likelihoods directly; for the type flags we debiased the raw type likelihoods using a correction based on the elliptical/spiral ratio determined after applying a 0.8 threshold, and then applied the same threshold to produce the flags. Therefore, the type flags do not correspond to simply applying a 0.8 threshold on the debiased type likelihoods, though for many galaxies these will agree.</i></tr></td>
 						</table>
 
 						<br />
@@ -112,16 +112,16 @@
 							</tr>
 							<tr><td colspan="2">This table gives classifications of galaxies included in the Galaxy Zoo sample which did not have spectra available in SDSS Data Release 7. It is not possible to estimate the bias in this sample without accurate redshifts, and so only the fraction of the vote in each of the six categories is given.</tr></td>
 							<tr>
-								<td>CSV (gzipped)</td><td><a href="http://galaxy-zoo-1.s3.amazonaws.com/GalaxyZoo1_DR_table3.csv.gz">GalaxyZoo1_DR_table3.csv.gz</a></td>
+								<td>CSV (gzipped)</td><td><a href="https://galaxy-zoo-1.s3.amazonaws.com/GalaxyZoo1_DR_table3.csv.gz">GalaxyZoo1_DR_table3.csv.gz</a></td>
 							</tr>
 							<tr>
-								<td>CSV (zip)</td><td><a href="http://galaxy-zoo-1.s3.amazonaws.com/GalaxyZoo1_DR_table3.csv.zip">GalaxyZoo1_DR_table3.csv.zip</a></td>
+								<td>CSV (zip)</td><td><a href="https://galaxy-zoo-1.s3.amazonaws.com/GalaxyZoo1_DR_table3.csv.zip">GalaxyZoo1_DR_table3.csv.zip</a></td>
 							</tr>
 							<tr>
-								<td>FITS</td><td><a href="http://galaxy-zoo-1.s3.amazonaws.com/GalaxyZoo1_DR_table3.fits">GalaxyZoo1_DR_table3.fits</a></td>
+								<td>FITS</td><td><a href="https://galaxy-zoo-1.s3.amazonaws.com/GalaxyZoo1_DR_table3.fits">GalaxyZoo1_DR_table3.fits</a></td>
 							</tr>
 							<tr>
-								<td>VOTable</td><td><a href="http://galaxy-zoo-1.s3.amazonaws.com/GalaxyZoo1_DR_table3.vot.gz">GalaxyZoo1_DR_table3.vot.gz</a></td>
+								<td>VOTable</td><td><a href="https://galaxy-zoo-1.s3.amazonaws.com/GalaxyZoo1_DR_table3.vot.gz">GalaxyZoo1_DR_table3.vot.gz</a></td>
 							</tr>
 						</table>
 
@@ -133,16 +133,16 @@
 							</tr>
 							<tr><td colspan="2">This table gives a series of measures of the classification confidence.</tr></td>
 							<tr>
-								<td>CSV (gzipped)</td><td><a href="http://galaxy-zoo-1.s3.amazonaws.com/GalaxyZoo1_DR_table4.csv.gz">GalaxyZoo1_DR_table4.csv.gz</a></td>
+								<td>CSV (gzipped)</td><td><a href="https://galaxy-zoo-1.s3.amazonaws.com/GalaxyZoo1_DR_table4.csv.gz">GalaxyZoo1_DR_table4.csv.gz</a></td>
 							</tr>
 							<tr>
-								<td>CSV (zip)</td><td><a href="http://galaxy-zoo-1.s3.amazonaws.com/GalaxyZoo1_DR_table4.csv.zip">GalaxyZoo1_DR_table4.csv.zip</a></td>
+								<td>CSV (zip)</td><td><a href="https://galaxy-zoo-1.s3.amazonaws.com/GalaxyZoo1_DR_table4.csv.zip">GalaxyZoo1_DR_table4.csv.zip</a></td>
 							</tr>
 							<tr>
-								<td>FITS</td><td><a href="http://galaxy-zoo-1.s3.amazonaws.com/GalaxyZoo1_DR_table4.fits">GalaxyZoo1_DR_table4.fits</a></td>
+								<td>FITS</td><td><a href="https://galaxy-zoo-1.s3.amazonaws.com/GalaxyZoo1_DR_table4.fits">GalaxyZoo1_DR_table4.fits</a></td>
 							</tr>
 							<tr>
-								<td>VOTable</td><td><a href="http://galaxy-zoo-1.s3.amazonaws.com/GalaxyZoo1_DR_table4.vot.gz">GalaxyZoo1_DR_table4.vot.gz</a></td>
+								<td>VOTable</td><td><a href="https://galaxy-zoo-1.s3.amazonaws.com/GalaxyZoo1_DR_table4.vot.gz">GalaxyZoo1_DR_table4.vot.gz</a></td>
 							</tr>
 						</table>
 
@@ -154,16 +154,16 @@
 							</tr>
 							<tr><td colspan="2">This table gives the results from the bias study that introduced mirrored images.</tr></td>
 							<tr>
-								<td>CSV (gzipped)</td><td><a href="http://galaxy-zoo-1.s3.amazonaws.com/GalaxyZoo1_DR_table5.csv.gz">GalaxyZoo1_DR_table5.csv.gz</a></td>
+								<td>CSV (gzipped)</td><td><a href="https://galaxy-zoo-1.s3.amazonaws.com/GalaxyZoo1_DR_table5.csv.gz">GalaxyZoo1_DR_table5.csv.gz</a></td>
 							</tr>
 							<tr>
-								<td>CSV (zip)</td><td><a href="http://galaxy-zoo-1.s3.amazonaws.com/GalaxyZoo1_DR_table5.csv.zip">GalaxyZoo1_DR_table5.csv.zip</a></td>
+								<td>CSV (zip)</td><td><a href="https://galaxy-zoo-1.s3.amazonaws.com/GalaxyZoo1_DR_table5.csv.zip">GalaxyZoo1_DR_table5.csv.zip</a></td>
 							</tr>
 							<tr>
-								<td>FITS</td><td><a href="http://galaxy-zoo-1.s3.amazonaws.com/GalaxyZoo1_DR_table5.fits">GalaxyZoo1_DR_table5.fits</a></td>
+								<td>FITS</td><td><a href="https://galaxy-zoo-1.s3.amazonaws.com/GalaxyZoo1_DR_table5.fits">GalaxyZoo1_DR_table5.fits</a></td>
 							</tr>
 							<tr>
-								<td>VOTable</td><td><a href="http://galaxy-zoo-1.s3.amazonaws.com/GalaxyZoo1_DR_table5.vot.gz">GalaxyZoo1_DR_table5.vot.gz</a></td>
+								<td>VOTable</td><td><a href="https://galaxy-zoo-1.s3.amazonaws.com/GalaxyZoo1_DR_table5.vot.gz">GalaxyZoo1_DR_table5.vot.gz</a></td>
 							</tr>
 						</table>
 
@@ -175,16 +175,16 @@
 							</tr>
 							<tr><td colspan="2">This table gives the results from the bias study that introduced monochrome images.</tr></td>
 							<tr>
-								<td>CSV (gzipped)</td><td><a href="http://galaxy-zoo-1.s3.amazonaws.com/GalaxyZoo1_DR_table6.csv.gz">GalaxyZoo1_DR_table6.csv.gz</a></td>
+								<td>CSV (gzipped)</td><td><a href="https://galaxy-zoo-1.s3.amazonaws.com/GalaxyZoo1_DR_table6.csv.gz">GalaxyZoo1_DR_table6.csv.gz</a></td>
 							</tr>
 							<tr>
-								<td>CSV (zip)</td><td><a href="http://galaxy-zoo-1.s3.amazonaws.com/GalaxyZoo1_DR_table6.csv.zip">GalaxyZoo1_DR_table6.csv.zip</a></td>
+								<td>CSV (zip)</td><td><a href="https://galaxy-zoo-1.s3.amazonaws.com/GalaxyZoo1_DR_table6.csv.zip">GalaxyZoo1_DR_table6.csv.zip</a></td>
 							</tr>
 							<tr>
-								<td>FITS</td><td><a href="http://galaxy-zoo-1.s3.amazonaws.com/GalaxyZoo1_DR_table6.fits">GalaxyZoo1_DR_table6.fits</a></td>
+								<td>FITS</td><td><a href="https://galaxy-zoo-1.s3.amazonaws.com/GalaxyZoo1_DR_table6.fits">GalaxyZoo1_DR_table6.fits</a></td>
 							</tr>
 							<tr>
-								<td>VOTable</td><td><a href="http://galaxy-zoo-1.s3.amazonaws.com/GalaxyZoo1_DR_table6.vot.gz">GalaxyZoo1_DR_table6.vot.gz</a></td>
+								<td>VOTable</td><td><a href="https://galaxy-zoo-1.s3.amazonaws.com/GalaxyZoo1_DR_table6.vot.gz">GalaxyZoo1_DR_table6.vot.gz</a></td>
 							</tr>
 						</table>
 
@@ -196,16 +196,16 @@
 							</tr>
 							<tr><td colspan="2">This table gives the fraction of votes in each of the six categories, combining results from the main and bias studies.</tr></td>
 							<tr>
-								<td>CSV (gzipped)</td><td><a href="http://galaxy-zoo-1.s3.amazonaws.com/GalaxyZoo1_DR_table7.csv.gz">GalaxyZoo1_DR_table7.csv.gz</a></td>
+								<td>CSV (gzipped)</td><td><a href="https://galaxy-zoo-1.s3.amazonaws.com/GalaxyZoo1_DR_table7.csv.gz">GalaxyZoo1_DR_table7.csv.gz</a></td>
 							</tr>
 							<tr>
-								<td>CSV (zip)</td><td><a href="http://galaxy-zoo-1.s3.amazonaws.com/GalaxyZoo1_DR_table7.csv.zip">GalaxyZoo1_DR_table7.csv.zip</a></td>
+								<td>CSV (zip)</td><td><a href="https://galaxy-zoo-1.s3.amazonaws.com/GalaxyZoo1_DR_table7.csv.zip">GalaxyZoo1_DR_table7.csv.zip</a></td>
 							</tr>
 							<tr>
-								<td>FITS</td><td><a href="http://galaxy-zoo-1.s3.amazonaws.com/GalaxyZoo1_DR_table7.fits">GalaxyZoo1_DR_table7.fits</a></td>
+								<td>FITS</td><td><a href="https://galaxy-zoo-1.s3.amazonaws.com/GalaxyZoo1_DR_table7.fits">GalaxyZoo1_DR_table7.fits</a></td>
 							</tr>
 							<tr>
-								<td>VOTable</td><td><a href="http://galaxy-zoo-1.s3.amazonaws.com/GalaxyZoo1_DR_table7.vot.gz">GalaxyZoo1_DR_table7.vot.gz</a></td>
+								<td>VOTable</td><td><a href="https://galaxy-zoo-1.s3.amazonaws.com/GalaxyZoo1_DR_table7.vot.gz">GalaxyZoo1_DR_table7.vot.gz</a></td>
 							</tr>
 						</table>
 
@@ -227,15 +227,15 @@
 
 					<div data-scroll-index="2">
 						<h2>AGN host galaxies</h2>
-						<p>This sample is presented in the Galaxy Zoo 1 paper on AGN host galaxies (<a href="http://adsabs.harvard.edu/abs/2010ApJ...711..284S" target="_blank">Schawinski et al., 2010, ApJ, 711, 284</a>). It is a volume-limited sample of galaxies (0.02 &lt; z &lt; 0.05, M<sub>z</sub> &lt; &ndash;19.5 AB) with emission line classifications, stellar masses, velocity dispersions and GZ1 morphological classifications. When using this sample, please cite Schawinski et al. (<a href="http://adsabs.harvard.edu/abs/2010ApJ...711..284S">2010</a>) and Lintott et al. (<a href="http://adsabs.harvard.edu/abs/2008MNRAS.389.1179L">2008</a>, <a href="http://adsabs.harvard.edu/abs/2011MNRAS.410..166L">2011</a>).</p>
-						<p>Download here: <a href="http://galaxy-zoo-1.s3.amazonaws.com/schawinski_GZ_2010_catalogue.fits.gz">schawinski_GZ_2010_catalogue.fits.gz</a></p>
+						<p>This sample is presented in the Galaxy Zoo 1 paper on AGN host galaxies (<a href="https://adsabs.harvard.edu/abs/2010ApJ...711..284S" target="_blank">Schawinski et al., 2010, ApJ, 711, 284</a>). It is a volume-limited sample of galaxies (0.02 &lt; z &lt; 0.05, M<sub>z</sub> &lt; &ndash;19.5 AB) with emission line classifications, stellar masses, velocity dispersions and GZ1 morphological classifications. When using this sample, please cite Schawinski et al. (<a href="https://adsabs.harvard.edu/abs/2010ApJ...711..284S">2010</a>) and Lintott et al. (<a href="https://adsabs.harvard.edu/abs/2008MNRAS.389.1179L">2008</a>, <a href="https://adsabs.harvard.edu/abs/2011MNRAS.410..166L">2011</a>).</p>
+						<p>Download here: <a href="https://galaxy-zoo-1.s3.amazonaws.com/schawinski_GZ_2010_catalogue.fits.gz">schawinski_GZ_2010_catalogue.fits.gz</a></p>
 
 						<table class="downloads">
 							<tr>
 							<tr><td>OBJID</td><td>SDSS DR7 object ID</tr>
 							<tr><td>RA, DEC</td><td>RA and dec in J2000.0</tr>
 							<tr><td>REDSHIFT</td><td>spectroscopic redshift from SDSS</tr>
-							<tr><td>GZ1_MORPHOLOGY</td><td>Galaxy Zoo 1 morphology according to the <a href="http://adsabs.harvard.edu/abs/2008MNRAS.388.1686L">Land et al. (2008)</a> "clean" criterion. This is an integer where 0 = indeterminate, 1 = early type, 3 = merger, 4 = late type</tr>
+							<tr><td>GZ1_MORPHOLOGY</td><td>Galaxy Zoo 1 morphology according to the <a href="https://adsabs.harvard.edu/abs/2008MNRAS.388.1686L">Land et al. (2008)</a> "clean" criterion. This is an integer where 0 = indeterminate, 1 = early type, 3 = merger, 4 = late type</tr>
 							<tr><td>BPT_CLASS</td><td>Spectroscopic classification of galaxy based on emission lines ratios in the BPT diagram. 0 = no emission lines, 1 = star-forming, 2 = composite, 3 = Seyfert and 4 = LINER.</tr>
 							<tr><td>U,G,R,I,Z</td><td>SDSS model magnitudes. These are extinction-corrected but not <i>k</i>-corrected.</tr>
 							<tr><td>SIGMA, SIGMA_ERR</td><td>Stellar velocity dispersion (and error) measured using GANDALF</tr>
@@ -249,7 +249,7 @@
 					<div data-scroll-index="3">
 						<h2>Overlapping Galaxy Pairs</h2>
                         <p>
-                          This section contains data from the Galaxy Zoo survey for overlapping galaxy pairs, useful for studies of dust absorption. Data is derived from the Zoo 1 and Zoo 2 periods (August 2007&ndash;April 2010), and is described in detail by <a href="http://adsabs.harvard.edu/abs/2013PASP..125....2K">Keel et al. (PASP, 2013, 125, 923)</a>. The catalog contains a total of 1990 galaxy pairs.</p>
+                          This section contains data from the Galaxy Zoo survey for overlapping galaxy pairs, useful for studies of dust absorption. Data is derived from the Zoo 1 and Zoo 2 periods (August 2007&ndash;April 2010), and is described in detail by <a href="https://adsabs.harvard.edu/abs/2013PASP..125....2K">Keel et al. (PASP, 2013, 125, 923)</a>. The catalog contains a total of 1990 galaxy pairs.</p>
 
 						<table class="downloads">
 							<tr>
@@ -304,7 +304,7 @@
 
 					<div data-scroll-index="4">
 						<h2>Merging galaxies</h2>
-						<p>This sample of merging galaxies is assembled from SDSS Galaxy Zoo 1 data. It is a homogenous sample of galaxies (0.005 &lt; z &lt; 0.1) with spectroscopy for at least one of two merging galaxies in the pair. Value-added GZ data includes the morphologies of the merging galaxies as well as the relative stage of the merger. For any use of data from this sample, please cite <a href="http://adsabs.harvard.edu/abs/2010MNRAS.401.1043D" target="_blank">Darg et al. (2010a)</a> and <a href="http://adsabs.harvard.edu/abs/2010MNRAS.401.1552D" target="_blank">Darg et al. (2010b)</a>.</p>
+						<p>This sample of merging galaxies is assembled from SDSS Galaxy Zoo 1 data. It is a homogenous sample of galaxies (0.005 &lt; z &lt; 0.1) with spectroscopy for at least one of two merging galaxies in the pair. Value-added GZ data includes the morphologies of the merging galaxies as well as the relative stage of the merger. For any use of data from this sample, please cite <a href="https://adsabs.harvard.edu/abs/2010MNRAS.401.1043D" target="_blank">Darg et al. (2010a)</a> and <a href="https://adsabs.harvard.edu/abs/2010MNRAS.401.1552D" target="_blank">Darg et al. (2010b)</a>.</p>
 
 						<table class="downloads">
 							<tr>
@@ -323,7 +323,7 @@
 
 					<div data-scroll-index="5">
 						<h2>Green peas</h2>
-						<p>&quot;Green peas&quot; are compact galaxies with extremely high star-formation rates. Their name comes from their appearance in colour SDSS images, which is due to strong [OIII] &#955;5007 emission that appears in the <i>r</i>-band filter for large numbers of low-redshift (0.112 &lt; z &lt; 0.360) galaxies. Properties of the initial sample are described in <a href="http://adsabs.harvard.edu/abs/2009MNRAS.399.1191C" target="_blank">Cardamone et al. (2009)</a>. Data below is from Table 4 in Cardamone et al. (2009).</p>
+						<p>&quot;Green peas&quot; are compact galaxies with extremely high star-formation rates. Their name comes from their appearance in colour SDSS images, which is due to strong [OIII] &#955;5007 emission that appears in the <i>r</i>-band filter for large numbers of low-redshift (0.112 &lt; z &lt; 0.360) galaxies. Properties of the initial sample are described in <a href="https://adsabs.harvard.edu/abs/2009MNRAS.399.1191C" target="_blank">Cardamone et al. (2009)</a>. Data below is from Table 4 in Cardamone et al. (2009).</p>
 
 						<table class="downloads">
 							<tr>
@@ -358,7 +358,7 @@
 						of a sample of disky
 						red spirals are
 						described in <a
-						href="http://adsabs.harvard.edu/abs/2010MNRAS.405..783M"
+						href="https://adsabs.harvard.edu/abs/2010MNRAS.405..783M"
 						target="_blank">Masters
 						et
 						al. (2010)</a>, and
@@ -392,29 +392,29 @@
 
 					<div data-scroll-index="7">
 						<h1>Galaxy Zoo 2</h1>
-                        <p> <a href="http://zoo2.galaxyzoo.org">Galaxy Zoo 2 (GZ2)</a> was the successor project to Galaxy Zoo. GZ2 extends the original Galaxy Zoo classifications for a subsample of the brightest and largest galaxies in the Legacy release, measuring more detailed morphological features. This includes galactic bars, spiral arm and pitch angle, bulges, edge-on galaxies, relative ellipticities, and many others. Two debiased Galaxy Zoo tables are provided, described in <a href="http://arxiv.org/abs/1308.3496v2">Willett et al. (2013) </a> and <a href="http://mnras.oxfordjournals.org/content/461/4/3663">Hart et al. (2016)</a>: we strongly advise the use of the <a href="http://mnras.oxfordjournals.org/content/461/4/3663">Hart et al. (2016)</a> table, as this debiases the GZ2 quetion tree most consistently.
+                        <p> <a href="http://zoo2.galaxyzoo.org">Galaxy Zoo 2 (GZ2)</a> was the successor project to Galaxy Zoo. GZ2 extends the original Galaxy Zoo classifications for a subsample of the brightest and largest galaxies in the Legacy release, measuring more detailed morphological features. This includes galactic bars, spiral arm and pitch angle, bulges, edge-on galaxies, relative ellipticities, and many others. Two debiased Galaxy Zoo tables are provided, described in <a href="https://arxiv.org/abs/1308.3496v2">Willett et al. (2013) </a> and <a href="https://mnras.oxfordjournals.org/content/461/4/3663">Hart et al. (2016)</a>: we strongly advise the use of the <a href="https://mnras.oxfordjournals.org/content/461/4/3663">Hart et al. (2016)</a> table, as this debiases the GZ2 quetion tree most consistently.
 					</div>
 
 
 					<div data-scroll-index="8">
 						<h2>Full Catalog</h2>
                         <p>These tables provide the GZ2 classifications for nearly 300,000 galaxies in the SDSS.
-						<p>The project description and data reduction is in <a href="http://arxiv.org/abs/1308.3496v2">Willett et al. 2013, MNRAS, 435, 2835</a> &mdash; please cite this paper if making any use of the GZ2 data. The table numbers below are the same as their order in the paper.</p>
+						<p>The project description and data reduction is in <a href="https://arxiv.org/abs/1308.3496v2">Willett et al. 2013, MNRAS, 435, 2835</a> &mdash; please cite this paper if making any use of the GZ2 data. The table numbers below are the same as their order in the paper.</p>
                                                 <br />
 						<table class="downloads">
 							<tr>
 								<td colspan="2" class="banner">Table 1 - Normal-depth sample with new debiasing method</td>
 							</tr>
-						    <tr><td colspan=2>Table 1 contains all galaxies that were debiased with the method described in <a href="http://mnras.oxfordjournals.org/content/461/4/3663">Hart et al. (2016)</a>. Galaxies with spectroscopic redshifts classified in GZ2 (from the GZ2 normal, extra and stripe82 normal depth), and apparent r-band magnitudes less than 17.0 are included (239,695 galaxies in total). Please cite <a href="http://mnras.oxfordjournals.org/content/461/4/3663">Hart et al. (2016)</a> when using these classifications.</td></tr>
-						    <tr><td colspan=2><a href="http://gz2hart.s3.amazonaws.com/gz2_hart16.txt">Column description and format</a></td></tr>
+						    <tr><td colspan=2>Table 1 contains all galaxies that were debiased with the method described in <a href="https://mnras.oxfordjournals.org/content/461/4/3663">Hart et al. (2016)</a>. Galaxies with spectroscopic redshifts classified in GZ2 (from the GZ2 normal, extra and stripe82 normal depth), and apparent r-band magnitudes less than 17.0 are included (239,695 galaxies in total). Please cite <a href="https://mnras.oxfordjournals.org/content/461/4/3663">Hart et al. (2016)</a> when using these classifications.</td></tr>
+						    <tr><td colspan=2><a href="https://gz2hart.s3.amazonaws.com/gz2_hart16.txt">Column description and format</a></td></tr>
 							<tr>
-								<td>CSV</td><td><a href="http://gz2hart.s3.amazonaws.com/gz2_hart16.csv.gz">http://gz2hart.s3.amazonaws.com/gz2_hart16.csv.gz</a></td>
+								<td>CSV</td><td><a href="https://gz2hart.s3.amazonaws.com/gz2_hart16.csv.gz">https://gz2hart.s3.amazonaws.com/gz2_hart16.csv.gz</a></td>
 							</tr>
 							<tr>
-								<td>FITS</td><td><a href="http://gz2hart.s3.amazonaws.com/gz2_hart16.fits.gz">http://gz2hart.s3.amazonaws.com/gz2_hart16.fits.gz</a></td>
+								<td>FITS</td><td><a href="https://gz2hart.s3.amazonaws.com/gz2_hart16.fits.gz">https://gz2hart.s3.amazonaws.com/gz2_hart16.fits.gz</a></td>
 							</tr>
 							<tr>
-								<td>VOTable</td><td><a href="http://gz2hart.s3.amazonaws.com/gz2_hart16.vot.gz">http://gz2hart.s3.amazonaws.com/gz2_hart16.vot.gz</a></td>
+								<td>VOTable</td><td><a href="https://gz2hart.s3.amazonaws.com/gz2_hart16.vot.gz">https://gz2hart.s3.amazonaws.com/gz2_hart16.vot.gz</a></td>
 							</tr>
 						</table>
 						<br />
@@ -426,13 +426,13 @@
 						    <tr><td colspan=2>Table 5 gives classifications of the 243,500 galaxies in the main sample with spectroscopic redshifts. This is the primary GZ2 data release, containing the largest number of galaxies and the most reliable morphologies.</td></tr>
 						    <tr><td colspan=2><a href="./data/gz2/zoo2MainSpecz.txt">Column description and format</a></td></tr>
 							<tr>
-								<td>CSV</td><td><a href="http://zooniverse-data.s3.amazonaws.com/galaxy-zoo-2/zoo2MainSpecz.csv.gz">zoo2MainSpecz.csv.gz</a></td>
+								<td>CSV</td><td><a href="https://zooniverse-data.s3.amazonaws.com/galaxy-zoo-2/zoo2MainSpecz.csv.gz">zoo2MainSpecz.csv.gz</a></td>
 							</tr>
 							<tr>
-								<td>FITS</td><td><a href="http://zooniverse-data.s3.amazonaws.com/galaxy-zoo-2/zoo2MainSpecz.fits.gz">zoo2MainSpecz.fits.gz</a></td>
+								<td>FITS</td><td><a href="https://zooniverse-data.s3.amazonaws.com/galaxy-zoo-2/zoo2MainSpecz.fits.gz">zoo2MainSpecz.fits.gz</a></td>
 							</tr>
 							<tr>
-								<td>VOTable</td><td><a href="http://zooniverse-data.s3.amazonaws.com/galaxy-zoo-2/zoo2MainSpecz.vot.gz">zoo2MainSpecz.vot.gz</a></td>
+								<td>VOTable</td><td><a href="https://zooniverse-data.s3.amazonaws.com/galaxy-zoo-2/zoo2MainSpecz.vot.gz">zoo2MainSpecz.vot.gz</a></td>
 							</tr>
 						</table>
 
@@ -445,13 +445,13 @@
 						    <tr><td colspan=2>Table 6 gives classifications of the 42,462 galaxies in the main sample with photometric redshifts only. Debiased morphologies for this sample are slightly more uncertain than Table 5, since the data reduction requires a redshift to adjust the morphology for classification bias.</td></tr>
 						    <tr><td colspan=2><a href="./data/gz2/zoo2MainPhotoz.txt">Column description and format</a></td></tr>
 							<tr>
-								<td>CSV</td><td><a href="http://zooniverse-data.s3.amazonaws.com/galaxy-zoo-2/zoo2MainPhotoz.csv.gz">zoo2MainPhotoz.csv.gz</a></td>
+								<td>CSV</td><td><a href="https://zooniverse-data.s3.amazonaws.com/galaxy-zoo-2/zoo2MainPhotoz.csv.gz">zoo2MainPhotoz.csv.gz</a></td>
 							</tr>
 							<tr>
-								<td>FITS</td><td><a href="http://zooniverse-data.s3.amazonaws.com/galaxy-zoo-2/zoo2MainPhotoz.fits.gz">zoo2MainPhotoz.fits.gz</a></td>
+								<td>FITS</td><td><a href="https://zooniverse-data.s3.amazonaws.com/galaxy-zoo-2/zoo2MainPhotoz.fits.gz">zoo2MainPhotoz.fits.gz</a></td>
 							</tr>
 							<tr>
-								<td>VOTable</td><td><a href="http://zooniverse-data.s3.amazonaws.com/galaxy-zoo-2/zoo2MainPhotoz.vot.gz">zoo2MainPhotoz.vot.gz</a></td>
+								<td>VOTable</td><td><a href="https://zooniverse-data.s3.amazonaws.com/galaxy-zoo-2/zoo2MainPhotoz.vot.gz">zoo2MainPhotoz.vot.gz</a></td>
 							</tr>
 						</table>
 
@@ -463,13 +463,13 @@
 						    <tr><td colspan=2>Table 7 gives classifications of the 17,787 galaxies classified in single-depth Stripe 82 images. The magnitude limit for Stripe 82 classifications (r&lt;17.7) is slightly deeper than the main samples. Some of these galaxies also appear in the main sample (Table 5).</td></tr>
 						    <tr><td colspan=2><a href="./data/gz2/zoo2Stripe82Normal.txt">Column description and format</a></td></tr>
 							<tr>
-								<td>CSV</td><td><a href="http://zooniverse-data.s3.amazonaws.com/galaxy-zoo-2/zoo2Stripe82Normal.csv.gz">zoo2Stripe82Normal.csv.gz</a></td>
+								<td>CSV</td><td><a href="https://zooniverse-data.s3.amazonaws.com/galaxy-zoo-2/zoo2Stripe82Normal.csv.gz">zoo2Stripe82Normal.csv.gz</a></td>
 							</tr>
 							<tr>
-								<td>FITS</td><td><a href="http://zooniverse-data.s3.amazonaws.com/galaxy-zoo-2/zoo2Stripe82Normal.fits.gz">zoo2Stripe82Normal.fits.gz</a></td>
+								<td>FITS</td><td><a href="https://zooniverse-data.s3.amazonaws.com/galaxy-zoo-2/zoo2Stripe82Normal.fits.gz">zoo2Stripe82Normal.fits.gz</a></td>
 							</tr>
 							<tr>
-								<td>VOTable</td><td><a href="http://zooniverse-data.s3.amazonaws.com/galaxy-zoo-2/zoo2Stripe82Normal.vot.gz">zoo2Stripe82Normal.vot.gz</a></td>
+								<td>VOTable</td><td><a href="https://zooniverse-data.s3.amazonaws.com/galaxy-zoo-2/zoo2Stripe82Normal.vot.gz">zoo2Stripe82Normal.vot.gz</a></td>
 							</tr>
 						</table>
 
@@ -481,13 +481,13 @@
 						    <tr><td colspan=2>Table 8 gives classifications of the first set of 19,765 galaxies classified in the coadded (runs 106 and 206) Stripe 82 images. Coadded images are made from combining between 47&ndash;55 individual exposures, resulting in better detection of fainter features and improved seeing. This set of images had no adjustments made to its background, which resulted in coloured background noise for some galaxies.</td></tr>
 						    <tr><td colspan=2><a href="./data/gz2/zoo2Stripe82Coadd1.txt">Column description and format</a></td></tr>
 							<tr>
-								<td>CSV</td><td><a href="http://zooniverse-data.s3.amazonaws.com/galaxy-zoo-2/zoo2Stripe82Coadd1.csv.gz">zoo2Stripe82Coadd1.csv.gz</a></td>
+								<td>CSV</td><td><a href="https://zooniverse-data.s3.amazonaws.com/galaxy-zoo-2/zoo2Stripe82Coadd1.csv.gz">zoo2Stripe82Coadd1.csv.gz</a></td>
 							</tr>
 							<tr>
-								<td>FITS</td><td><a href="http://zooniverse-data.s3.amazonaws.com/galaxy-zoo-2/zoo2Stripe82Coadd1.fits.gz">zoo2Stripe82Coadd1.fits.gz</a></td>
+								<td>FITS</td><td><a href="https://zooniverse-data.s3.amazonaws.com/galaxy-zoo-2/zoo2Stripe82Coadd1.fits.gz">zoo2Stripe82Coadd1.fits.gz</a></td>
 							</tr>
 							<tr>
-								<td>VOTable</td><td><a href="http://zooniverse-data.s3.amazonaws.com/galaxy-zoo-2/zoo2Stripe82Coadd1.vot.gz">zoo2Stripe82Coadd1.vot.gz</a></td>
+								<td>VOTable</td><td><a href="https://zooniverse-data.s3.amazonaws.com/galaxy-zoo-2/zoo2Stripe82Coadd1.vot.gz">zoo2Stripe82Coadd1.vot.gz</a></td>
 							</tr>
 						</table>
 
@@ -499,13 +499,13 @@
 						    <tr><td colspan=2>Table 9 gives classifications of the second set of 19,761 galaxies classified in the coadded (runs 106 and 206) Stripe 82 images. Coadded images are made from combining between 47&ndash;55 individual exposures, resulting in better detection of fainter features and improved seeing. This set of images applied a modest colour desaturation to de-emphasise background noise in the coadded data.</td></tr>
 						    <tr><td colspan=2><a href="./data/gz2/zoo2Stripe82Coadd2.txt">Column description and format</a></td></tr>
 							<tr>
-								<td>CSV</td><td><a href="http://zooniverse-data.s3.amazonaws.com/galaxy-zoo-2/zoo2Stripe82Coadd2.csv.gz">zoo2Stripe82Coadd2.csv.gz</a></td>
+								<td>CSV</td><td><a href="https://zooniverse-data.s3.amazonaws.com/galaxy-zoo-2/zoo2Stripe82Coadd2.csv.gz">zoo2Stripe82Coadd2.csv.gz</a></td>
 							</tr>
 							<tr>
-								<td>FITS</td><td><a href="http://zooniverse-data.s3.amazonaws.com/galaxy-zoo-2/zoo2Stripe82Coadd2.fits.gz">zoo2Stripe82Coadd2.fits.gz</a></td>
+								<td>FITS</td><td><a href="https://zooniverse-data.s3.amazonaws.com/galaxy-zoo-2/zoo2Stripe82Coadd2.fits.gz">zoo2Stripe82Coadd2.fits.gz</a></td>
 							</tr>
 							<tr>
-								<td>VOTable</td><td><a href="http://zooniverse-data.s3.amazonaws.com/galaxy-zoo-2/zoo2Stripe82Coadd2.vot.gz">zoo2Stripe82Coadd2.vot.gz</a></td>
+								<td>VOTable</td><td><a href="https://zooniverse-data.s3.amazonaws.com/galaxy-zoo-2/zoo2Stripe82Coadd2.vot.gz">zoo2Stripe82Coadd2.vot.gz</a></td>
 							</tr>
 						</table>
 
@@ -518,13 +518,13 @@
 						    <tr><td colspan=2>This table provides pre-matched sets of metadata for the Galaxy Zoo 2 samples taken from DR7. This includes coordinates, photometry, size, and redshifts (where present). For science cases, we encourage users to instead use the latest measurements from the latest data release.</td></tr>
 						    <tr><td colspan=2><a href="./data/gz2/gz2sample.txt">Column description and format</a></td></tr>
 							<tr>
-								<td>CSV</td><td><a href="http://zooniverse-data.s3.amazonaws.com/galaxy-zoo-2/gz2sample.csv.gz">gz2sample.csv.gz</a></td>
+								<td>CSV</td><td><a href="https://zooniverse-data.s3.amazonaws.com/galaxy-zoo-2/gz2sample.csv.gz">gz2sample.csv.gz</a></td>
 							</tr>
 							<tr>
-								<td>FITS</td><td><a href="http://zooniverse-data.s3.amazonaws.com/galaxy-zoo-2/gz2sample.fits.gz">gz2sample.fits.gz</a></td>
+								<td>FITS</td><td><a href="https://zooniverse-data.s3.amazonaws.com/galaxy-zoo-2/gz2sample.fits.gz">gz2sample.fits.gz</a></td>
 							</tr>
 							<tr>
-								<td>VOTable</td><td><a href="http://zooniverse-data.s3.amazonaws.com/galaxy-zoo-2/gz2sample.vot.gz">gz2sample.vot.gz</a></td>
+								<td>VOTable</td><td><a href="https://zooniverse-data.s3.amazonaws.com/galaxy-zoo-2/gz2sample.vot.gz">gz2sample.vot.gz</a></td>
 							</tr>
 						</table>
 
@@ -533,7 +533,7 @@
 
 
 
-                        <p> The code used to reduce GZ2 is available on GitHub &mdash; please take a look either at its <a href="http://willettk.github.io/galaxyzoo2/">webpage</a> or fork it from the <a href="https://github.com/willettk/galaxyzoo2">repository</a> if you're interested in the details.
+                        <p> The code used to reduce GZ2 is available on GitHub &mdash; please take a look either at its <a href="https://willettk.github.io/galaxyzoo2/">webpage</a> or fork it from the <a href="https://github.com/willettk/galaxyzoo2">repository</a> if you're interested in the details.
 						<h3>CASjobs</h3>
 						<p>The GZ2 catalog is also accessible via <a href="http://skyserver.sdss3.org/CasJobs/">CasJobs</a> in Data Release 10. The table names in CasJobs are:</p>
 						<p>
@@ -553,7 +553,7 @@
 
 					<div data-scroll-index="9">
 						<h2>Bar lengths</h2>
-						<p>In conjunction with Galaxy Zoo 2, we ran a parallel project to measure lengths, widths, and angles of galactic bars using an interactive interface. See <a href="http://adsabs.harvard.edu/cgi-bin/bib_query?arXiv:1104.5394">Hoyle et al. (2011)</a> for a description of the project and scientific results. The full set of results can be downloaded below.</p>
+						<p>In conjunction with Galaxy Zoo 2, we ran a parallel project to measure lengths, widths, and angles of galactic bars using an interactive interface. See <a href="https://adsabs.harvard.edu/cgi-bin/bib_query?arXiv:1104.5394">Hoyle et al. (2011)</a> for a description of the project and scientific results. The full set of results can be downloaded below.</p>
 						<br />
 						<table class="downloads">
 							<tr>
@@ -588,7 +588,7 @@
                             <li><a href="./data/dustlanes/GALEX_photometry.txt">UV photometry from GALEX</a>
                         </ul>
 
-                        <p>Please cite the DLSG (<a href="http://adsabs.harvard.edu/cgi-bin/bib_query?arXiv:1107.5306">Kaviraj et al. 2012</a>; <a href="http://adsabs.harvard.edu/cgi-bin/bib_query?arXiv:1107.5310">Shabala et al. 2012</a>; <a href="http://adsabs.harvard.edu/doi/10.1093/mnras/stt1629">Kaviraj et al. 2013</a>) and Galaxy Zoo 2 (<a href="http://arxiv.org/abs/1308.3496v2">Willett et al. 2013</a>) publications if using this data.</p>
+                        <p>Please cite the DLSG (<a href="https://adsabs.harvard.edu/cgi-bin/bib_query?arXiv:1107.5306">Kaviraj et al. 2012</a>; <a href="https://adsabs.harvard.edu/cgi-bin/bib_query?arXiv:1107.5310">Shabala et al. 2012</a>; <a href="https://adsabs.harvard.edu/doi/10.1093/mnras/stt1629">Kaviraj et al. 2013</a>) and Galaxy Zoo 2 (<a href="https://arxiv.org/abs/1308.3496v2">Willett et al. 2013</a>) publications if using this data.</p>
 
 						<br />
 					</div>
@@ -610,13 +610,13 @@
 						    <tr><td colspan=2>Table 4 contains classifications of 113,705 galaxies aggregated from four <i>HST</i> surveys: AEGIS, COSMOS, GEMS, and GOODS (5-epoch imaging only). This is the primary output of the GZH project, with calibrated and debiased morphological classifications for galaxies out to z &#8818; 4.</td></tr>
 						    <tr><td colspan=2><a href="./data/gzh/column_descriptions_main.tsv">Column description and format</a></td></tr>
 							<tr>
-								<td>CSV</td><td><a href="http://zooniverse-data.s3.amazonaws.com/galaxy-zoo-hubble/gz_hubble_main.csv.gz">gz_hubble_main.csv.gz</a></td>
+								<td>CSV</td><td><a href="https://zooniverse-data.s3.amazonaws.com/galaxy-zoo-hubble/gz_hubble_main.csv.gz">gz_hubble_main.csv.gz</a></td>
 							</tr>
 							<tr>
-								<td>FITS</td><td><a href="http://zooniverse-data.s3.amazonaws.com/galaxy-zoo-hubble/gz_hubble_main.fits.gz">gz_hubble_main.fits.gz</a></td>
+								<td>FITS</td><td><a href="https://zooniverse-data.s3.amazonaws.com/galaxy-zoo-hubble/gz_hubble_main.fits.gz">gz_hubble_main.fits.gz</a></td>
 							</tr>
 							<tr>
-								<td>VOTable</td><td><a href="http://zooniverse-data.s3.amazonaws.com/galaxy-zoo-hubble/gz_hubble_main.vot.gz">gz_hubble_main.vot.gz</a></td>
+								<td>VOTable</td><td><a href="https://zooniverse-data.s3.amazonaws.com/galaxy-zoo-hubble/gz_hubble_main.vot.gz">gz_hubble_main.vot.gz</a></td>
 							</tr>
 						</table>
 
@@ -629,13 +629,13 @@
 						    <tr><td colspan=2>Table 5 contains classifications of 3,927 galaxies from the COSMOS survey. These images were faded to very low colour saturation before classification, and tested the effects of colour gradients on morphological consistency.</td></tr>
 						    <tr><td colspan=2><a href="./data/gzh/column_descriptions_faded.tsv">Column description and format</a></td></tr>
 							<tr>
-								<td>CSV</td><td><a href="http://zooniverse-data.s3.amazonaws.com/galaxy-zoo-hubble/gz_hubble_faded.csv.gz">gz_hubble_faded.csv.gz</a></td>
+								<td>CSV</td><td><a href="https://zooniverse-data.s3.amazonaws.com/galaxy-zoo-hubble/gz_hubble_faded.csv.gz">gz_hubble_faded.csv.gz</a></td>
 							</tr>
 							<tr>
-								<td>FITS</td><td><a href="http://zooniverse-data.s3.amazonaws.com/galaxy-zoo-hubble/gz_hubble_faded.fits.gz">gz_hubble_faded.fits.gz</a></td>
+								<td>FITS</td><td><a href="https://zooniverse-data.s3.amazonaws.com/galaxy-zoo-hubble/gz_hubble_faded.fits.gz">gz_hubble_faded.fits.gz</a></td>
 							</tr>
 							<tr>
-								<td>VOTable</td><td><a href="http://zooniverse-data.s3.amazonaws.com/galaxy-zoo-hubble/gz_hubble_faded.vot.gz">gz_hubble_faded.vot.gz</a></td>
+								<td>VOTable</td><td><a href="https://zooniverse-data.s3.amazonaws.com/galaxy-zoo-hubble/gz_hubble_faded.vot.gz">gz_hubble_faded.vot.gz</a></td>
 							</tr>
 						</table>
 
@@ -648,13 +648,13 @@
 						    <tr><td colspan=2>Table 6 contains classifications of 3,927 galaxies from the COSMOS survey. These colour composite images had the red and blue channels swapped from default settings, and tested the effects of colour perception on morphological consistency.</td></tr>
 						    <tr><td colspan=2><a href="./data/gzh/column_descriptions_recoloured.tsv">Column description and format</a></td></tr>
 							<tr>
-								<td>CSV</td><td><a href="http://zooniverse-data.s3.amazonaws.com/galaxy-zoo-hubble/gz_hubble_recoloured.csv.gz">gz_hubble_recoloured.csv.gz</a></td>
+								<td>CSV</td><td><a href="https://zooniverse-data.s3.amazonaws.com/galaxy-zoo-hubble/gz_hubble_recoloured.csv.gz">gz_hubble_recoloured.csv.gz</a></td>
 							</tr>
 							<tr>
-								<td>FITS</td><td><a href="http://zooniverse-data.s3.amazonaws.com/galaxy-zoo-hubble/gz_hubble_recoloured.fits.gz">gz_hubble_recoloured.fits.gz</a></td>
+								<td>FITS</td><td><a href="https://zooniverse-data.s3.amazonaws.com/galaxy-zoo-hubble/gz_hubble_recoloured.fits.gz">gz_hubble_recoloured.fits.gz</a></td>
 							</tr>
 							<tr>
-								<td>VOTable</td><td><a href="http://zooniverse-data.s3.amazonaws.com/galaxy-zoo-hubble/gz_hubble_recoloured.vot.gz">gz_hubble_recoloured.vot.gz</a></td>
+								<td>VOTable</td><td><a href="https://zooniverse-data.s3.amazonaws.com/galaxy-zoo-hubble/gz_hubble_recoloured.vot.gz">gz_hubble_recoloured.vot.gz</a></td>
 							</tr>
 						</table>
 
@@ -667,13 +667,13 @@
 						    <tr><td colspan=2>Table 7 contains classifications of 6,144 galaxies from the GOODS-N and GOODS-S surveys. These images are shallow exposures created from 2-epoch imaging, as contrasted with the deeper 5-epoch imaging of galaxies from GOODS in Table 4.</td></tr>
 						    <tr><td colspan=2><a href="./data/gzh/column_descriptions_goods_shallow.tsv">Column description and format</a></td></tr>
 							<tr>
-								<td>CSV</td><td><a href="http://zooniverse-data.s3.amazonaws.com/galaxy-zoo-hubble/gz_hubble_goods_shallow.csv.gz">gz_hubble_goods_shallow.csv.gz</a></td>
+								<td>CSV</td><td><a href="https://zooniverse-data.s3.amazonaws.com/galaxy-zoo-hubble/gz_hubble_goods_shallow.csv.gz">gz_hubble_goods_shallow.csv.gz</a></td>
 							</tr>
 							<tr>
-								<td>FITS</td><td><a href="http://zooniverse-data.s3.amazonaws.com/galaxy-zoo-hubble/gz_hubble_goods_shallow.fits.gz">gz_hubble_goods_shallow.fits.gz</a></td>
+								<td>FITS</td><td><a href="https://zooniverse-data.s3.amazonaws.com/galaxy-zoo-hubble/gz_hubble_goods_shallow.fits.gz">gz_hubble_goods_shallow.fits.gz</a></td>
 							</tr>
 							<tr>
-								<td>VOTable</td><td><a href="http://zooniverse-data.s3.amazonaws.com/galaxy-zoo-hubble/gz_hubble_goods_shallow.vot.gz">gz_hubble_goods_shallow.vot.gz</a></td>
+								<td>VOTable</td><td><a href="https://zooniverse-data.s3.amazonaws.com/galaxy-zoo-hubble/gz_hubble_goods_shallow.vot.gz">gz_hubble_goods_shallow.vot.gz</a></td>
 							</tr>
 						</table>
 
@@ -686,13 +686,13 @@
 						    <tr><td colspan=2>Table 8 contains classifications of 21,522 galaxies located in SDSS Stripe 82. The images come from single-epoch observations by SDSS, but use the same decision tree and interface as the data in Tables 4-7. These images provide a low-redshift counterpart to the data from the various Hubble surveys.  </td></tr>
 						    <tr><td colspan=2><a href="./data/gzh/column_descriptions_sdss_single.tsv">Column description and format</a></td></tr>
 							<tr>
-								<td>CSV</td><td><a href="http://zooniverse-data.s3.amazonaws.com/galaxy-zoo-hubble/gz_hubble_sdss_single.csv.gz">gz_hubble_sdss_single.csv.gz</a></td>
+								<td>CSV</td><td><a href="https://zooniverse-data.s3.amazonaws.com/galaxy-zoo-hubble/gz_hubble_sdss_single.csv.gz">gz_hubble_sdss_single.csv.gz</a></td>
 							</tr>
 							<tr>
-								<td>FITS</td><td><a href="http://zooniverse-data.s3.amazonaws.com/galaxy-zoo-hubble/gz_hubble_sdss_single.fits.gz">gz_hubble_sdss_single.fits.gz</a></td>
+								<td>FITS</td><td><a href="https://zooniverse-data.s3.amazonaws.com/galaxy-zoo-hubble/gz_hubble_sdss_single.fits.gz">gz_hubble_sdss_single.fits.gz</a></td>
 							</tr>
 							<tr>
-								<td>VOTable</td><td><a href="http://zooniverse-data.s3.amazonaws.com/galaxy-zoo-hubble/gz_hubble_sdss_single.vot.gz">gz_hubble_sdss_single.vot.gz</a></td>
+								<td>VOTable</td><td><a href="https://zooniverse-data.s3.amazonaws.com/galaxy-zoo-hubble/gz_hubble_sdss_single.vot.gz">gz_hubble_sdss_single.vot.gz</a></td>
 							</tr>
 						</table>
 
@@ -705,13 +705,13 @@
 						    <tr><td colspan=2>Table 9 contains classifications of 30,339 galaxies located in SDSS Stripe 82. The images come from co-added observations over dozens of epochs by SDSS, as compared to the shallower single-epoch images in Table 8. </td></tr>
 						    <tr><td colspan=2><a href="./data/gzh/column_descriptions_sdss_coadd.tsv">Column description and format</a></td></tr>
 							<tr>
-								<td>CSV</td><td><a href="http://zooniverse-data.s3.amazonaws.com/galaxy-zoo-hubble/gz_hubble_sdss_coadd.csv.gz">gz_hubble_sdss_coadd.csv.gz</a></td>
+								<td>CSV</td><td><a href="https://zooniverse-data.s3.amazonaws.com/galaxy-zoo-hubble/gz_hubble_sdss_coadd.csv.gz">gz_hubble_sdss_coadd.csv.gz</a></td>
 							</tr>
 							<tr>
-								<td>FITS</td><td><a href="http://zooniverse-data.s3.amazonaws.com/galaxy-zoo-hubble/gz_hubble_sdss_coadd.fits.gz">gz_hubble_sdss_coadd.fits.gz</a></td>
+								<td>FITS</td><td><a href="https://zooniverse-data.s3.amazonaws.com/galaxy-zoo-hubble/gz_hubble_sdss_coadd.fits.gz">gz_hubble_sdss_coadd.fits.gz</a></td>
 							</tr>
 							<tr>
-								<td>VOTable</td><td><a href="http://zooniverse-data.s3.amazonaws.com/galaxy-zoo-hubble/gz_hubble_sdss_coadd.vot.gz">gz_hubble_sdss_coadd.vot.gz</a></td>
+								<td>VOTable</td><td><a href="https://zooniverse-data.s3.amazonaws.com/galaxy-zoo-hubble/gz_hubble_sdss_coadd.vot.gz">gz_hubble_sdss_coadd.vot.gz</a></td>
 							</tr>
 						</table>
 
@@ -724,13 +724,13 @@
 						    <tr><td colspan=2>Table 10 contains classifications of 2,961 HST images that contain both a real galaxy and a simulated nuclear point source of varying intensity and colour. These images tested the effects of optically-bright AGN on morphological classification. </td></tr>
 						    <tr><td colspan=2><a href="./data/gzh/column_descriptions_simulated_agn.tsv">Column description and format</a></td></tr>
 							<tr>
-								<td>CSV</td><td><a href="http://zooniverse-data.s3.amazonaws.com/galaxy-zoo-hubble/gz_hubble_simulated_agn.csv.gz">gz_hubble_simulated_agn.csv.gz</a></td>
+								<td>CSV</td><td><a href="https://zooniverse-data.s3.amazonaws.com/galaxy-zoo-hubble/gz_hubble_simulated_agn.csv.gz">gz_hubble_simulated_agn.csv.gz</a></td>
 							</tr>
 							<tr>
-								<td>FITS</td><td><a href="http://zooniverse-data.s3.amazonaws.com/galaxy-zoo-hubble/gz_hubble_simulated_agn.fits.gz">gz_hubble_simulated_agn.fits.gz</a></td>
+								<td>FITS</td><td><a href="https://zooniverse-data.s3.amazonaws.com/galaxy-zoo-hubble/gz_hubble_simulated_agn.fits.gz">gz_hubble_simulated_agn.fits.gz</a></td>
 							</tr>
 							<tr>
-								<td>VOTable</td><td><a href="http://zooniverse-data.s3.amazonaws.com/galaxy-zoo-hubble/gz_hubble_simulated_agn.vot.gz">gz_hubble_simulated_agn.vot.gz</a></td>
+								<td>VOTable</td><td><a href="https://zooniverse-data.s3.amazonaws.com/galaxy-zoo-hubble/gz_hubble_simulated_agn.vot.gz">gz_hubble_simulated_agn.vot.gz</a></td>
 							</tr>
 						</table>
 
@@ -741,25 +741,25 @@
 								<td colspan="3" class="banner">Metadata</td>
 							</tr>
 						    <tr><td colspan=3>These tables contain useful metadata matched to the morphological data in Tables 4&ndash;9. This includes (where available) redshifts, magnitudes, angular sizes, automatically-measured morphological parameters, and additional flags from the parent surveys.</td></tr>
-						    <tr><td colspan=3><a href="http://zooniverse-data.s3.amazonaws.com/galaxy-zoo-hubble/galaxy-zoo-hubble-metadata.zip"><b>Single zipped file</b></a> including column descriptions and FITS tables with metadata for all GZ: Hubble images</td></tr>
+						    <tr><td colspan=3><a href="https://zooniverse-data.s3.amazonaws.com/galaxy-zoo-hubble/galaxy-zoo-hubble-metadata.zip"><b>Single zipped file</b></a> including column descriptions and FITS tables with metadata for all GZ: Hubble images</td></tr>
                             <tr><td></td></tr>
 							<tr>
-								<td>GZH main sample</td><td><a href="http://zooniverse-data.s3.amazonaws.com/galaxy-zoo-hubble/metadata/csv/metadata_main.csv">CSV</a></td><td><a href="http://zooniverse-data.s3.amazonaws.com/galaxy-zoo-hubble/metadata/fits/metadata_main.fits">FITS</a></td>
+								<td>GZH main sample</td><td><a href="https://zooniverse-data.s3.amazonaws.com/galaxy-zoo-hubble/metadata/csv/metadata_main.csv">CSV</a></td><td><a href="https://zooniverse-data.s3.amazonaws.com/galaxy-zoo-hubble/metadata/fits/metadata_main.fits">FITS</a></td>
 							</tr>
 							<tr>
-								<td>GZH GOODS, shallow-depth imaging</td><td><a href="http://zooniverse-data.s3.amazonaws.com/galaxy-zoo-hubble/metadata/csv/metadata_goods_shallow.csv">CSV</a></td><td><a href="http://zooniverse-data.s3.amazonaws.com/galaxy-zoo-hubble/metadata/fits/metadata_goods_shallow.fits">FITS</a></td>
+								<td>GZH GOODS, shallow-depth imaging</td><td><a href="https://zooniverse-data.s3.amazonaws.com/galaxy-zoo-hubble/metadata/csv/metadata_goods_shallow.csv">CSV</a></td><td><a href="https://zooniverse-data.s3.amazonaws.com/galaxy-zoo-hubble/metadata/fits/metadata_goods_shallow.fits">FITS</a></td>
 							</tr>
 							<tr>
-								<td>GZH GOODS, full-depth imaging</td><td><a href="http://zooniverse-data.s3.amazonaws.com/galaxy-zoo-hubble/metadata/csv/metadata_goods_full.csv">CSV</a></td><td><a href="http://zooniverse-data.s3.amazonaws.com/galaxy-zoo-hubble/metadata/fits/metadata_goods_full.fits">FITS</a></td>
+								<td>GZH GOODS, full-depth imaging</td><td><a href="https://zooniverse-data.s3.amazonaws.com/galaxy-zoo-hubble/metadata/csv/metadata_goods_full.csv">CSV</a></td><td><a href="https://zooniverse-data.s3.amazonaws.com/galaxy-zoo-hubble/metadata/fits/metadata_goods_full.fits">FITS</a></td>
 							</tr>
 							<tr>
-								<td>GZH SDSS, coadded imaging</td><td><a href="http://zooniverse-data.s3.amazonaws.com/galaxy-zoo-hubble/metadata/csv/metadata_sdss_coadd.csv">CSV</a></td><td><a href="http://zooniverse-data.s3.amazonaws.com/galaxy-zoo-hubble/metadata/fits/metadata_sdss_coadd.fits">FITS</a></td>
+								<td>GZH SDSS, coadded imaging</td><td><a href="https://zooniverse-data.s3.amazonaws.com/galaxy-zoo-hubble/metadata/csv/metadata_sdss_coadd.csv">CSV</a></td><td><a href="https://zooniverse-data.s3.amazonaws.com/galaxy-zoo-hubble/metadata/fits/metadata_sdss_coadd.fits">FITS</a></td>
 							</tr>
 							<tr>
-								<td>GZH SDSS, single-depth imaging</td><td><a href="http://zooniverse-data.s3.amazonaws.com/galaxy-zoo-hubble/metadata/csv/metadata_sdss_singledepth.csv">CSV</a></td><td><a href="http://zooniverse-data.s3.amazonaws.com/galaxy-zoo-hubble/metadata/fits/metadata_sdss_singledepth.fits">FITS</a></td>
+								<td>GZH SDSS, single-depth imaging</td><td><a href="https://zooniverse-data.s3.amazonaws.com/galaxy-zoo-hubble/metadata/csv/metadata_sdss_singledepth.csv">CSV</a></td><td><a href="https://zooniverse-data.s3.amazonaws.com/galaxy-zoo-hubble/metadata/fits/metadata_sdss_singledepth.fits">FITS</a></td>
 							</tr>
 							<tr>
-								<td>FERENGI-processed images</td><td><a href="http://zooniverse-data.s3.amazonaws.com/galaxy-zoo-hubble/metadata/csv/metadata_ferengi.csv">CSV</a></td><td><a href="http://zooniverse-data.s3.amazonaws.com/galaxy-zoo-hubble/metadata/fits/metadata_ferengi.fits">FITS</a></td>
+								<td>FERENGI-processed images</td><td><a href="https://zooniverse-data.s3.amazonaws.com/galaxy-zoo-hubble/metadata/csv/metadata_ferengi.csv">CSV</a></td><td><a href="https://zooniverse-data.s3.amazonaws.com/galaxy-zoo-hubble/metadata/fits/metadata_ferengi.fits">FITS</a></td>
 							</tr>
 						</table>
 
@@ -767,7 +767,7 @@
 
 					<div data-scroll-index="13">
 						<h2>Bar fraction evolution</h2>
-						<p><a href="http://arXiv.org/abs/1401.3334">Melvin et al. (2014)</a> used GZ2 and preliminary GZ: Hubble data to study the evolution of the bar fraction in galaxies over cosmic timescales. Presented here are links to webpages with the HST postage stamp images for the different galaxy samples.</p>
+						<p><a href="https://arXiv.org/abs/1401.3334">Melvin et al. (2014)</a> used GZ2 and preliminary GZ: Hubble data to study the evolution of the bar fraction in galaxies over cosmic timescales. Presented here are links to webpages with the HST postage stamp images for the different galaxy samples.</p>
 
                         <ul>
                             <li>GZ: Hubble disk galaxy sample split into three stellar mass bins:
@@ -799,13 +799,13 @@
 						    <tr><td colspan=2>Raw and weighted classifications for the full Galaxy Zoo: CANDELS sample. The rows/columns are transposed from the version in the printed article (which was done only to illustrate form and content). In this table, each row corresponds to an individual galaxies and the columns to the various morphological parameters. This table includes raw and weighted morphological classifications for all tasks in the GZC classification tree for each of the 49,555 unique sources in the sample.</td></tr>
 						    <tr><td colspan=2><a href="./data/candels/gzc_table2_description.txt">Column description and format</a></td></tr>
 							<tr>
-								<td>CSV</td><td><a href="http://zooniverse-data.s3.amazonaws.com/galaxy-zoo-candels/gz_candels_table_2_main_release.csv">gz_candels_table_2_main_release.csv</a></td>
+								<td>CSV</td><td><a href="https://zooniverse-data.s3.amazonaws.com/galaxy-zoo-candels/gz_candels_table_2_main_release.csv">gz_candels_table_2_main_release.csv</a></td>
 							</tr>
 							<tr>
-								<td>FITS</td><td><a href="http://zooniverse-data.s3.amazonaws.com/galaxy-zoo-candels/gz_candels_table_2_main_release.fits">gz_candels_table_2_main_release.fits</a></td>
+								<td>FITS</td><td><a href="https://zooniverse-data.s3.amazonaws.com/galaxy-zoo-candels/gz_candels_table_2_main_release.fits">gz_candels_table_2_main_release.fits</a></td>
 							</tr>
 							<tr>
-								<td>VOTable</td><td><a href="http://zooniverse-data.s3.amazonaws.com/galaxy-zoo-candels/gz_candels_table_2_main_release.vot">gz_candels_table_2_main_release.vot</a></td>
+								<td>VOTable</td><td><a href="https://zooniverse-data.s3.amazonaws.com/galaxy-zoo-candels/gz_candels_table_2_main_release.vot">gz_candels_table_2_main_release.vot</a></td>
 							</tr>
 							<tr>
 								<td colspan="2" class="banner">Table 4 - depth corrections</td>
@@ -813,13 +813,13 @@
 						    <tr><td colspan=2>Classifications and depth-corrections for 10,648 galaxies in GZC that had imaging at multiple co-added epochs. If your science question benefits from having classifications from images comparable depth across an entire sample, we recommend using the <b>_deepcorr</b> classifications in this table for subjects in the deeper fields.</td></tr>
 						    <tr><td colspan=2><a href="./data/candels/gzc_table4_description.txt">Column description and format</a></td></tr>
 							<tr>
-								<td>CSV</td><td><a href="http://zooniverse-data.s3.amazonaws.com/galaxy-zoo-candels/gz_candels_table_4_depth_corr.csv">gz_candels_table_4_depth_corr.csv</a></td>
+								<td>CSV</td><td><a href="https://zooniverse-data.s3.amazonaws.com/galaxy-zoo-candels/gz_candels_table_4_depth_corr.csv">gz_candels_table_4_depth_corr.csv</a></td>
 							</tr>
 							<tr>
-								<td>FITS</td><td><a href="http://zooniverse-data.s3.amazonaws.com/galaxy-zoo-candels/gz_candels_table_4_depth_corr.fits">gz_candels_table_4_depth_corr.fits</a></td>
+								<td>FITS</td><td><a href="https://zooniverse-data.s3.amazonaws.com/galaxy-zoo-candels/gz_candels_table_4_depth_corr.fits">gz_candels_table_4_depth_corr.fits</a></td>
 							</tr>
 							<tr>
-								<td>VOTable</td><td><a href="http://zooniverse-data.s3.amazonaws.com/galaxy-zoo-candels/gz_candels_table_4_depth_corr.vot">gz_candels_table_4_depth_corr.vot</a></td>
+								<td>VOTable</td><td><a href="https://zooniverse-data.s3.amazonaws.com/galaxy-zoo-candels/gz_candels_table_4_depth_corr.vot">gz_candels_table_4_depth_corr.vot</a></td>
 							</tr>
 
 						</table>


### PR DESCRIPTION
Not all links are changed (some don't work with https), but all AWS, ADS and arXiv links are.