### PR TITLE
Use local blob storage deploy

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -8,14 +8,31 @@ on:
 
 jobs:
   deploy:
-    name: Deploy data.galaxyzoo.org
-    uses: zooniverse/ci-cd/.github/workflows/deploy_static.yaml@main
-    with:
-      source: 'public'
-      target: 'zooniverse-static/data.galaxyzoo.org'
-      max_age: 600
-    secrets:
-      creds: ${{ secrets.AZURE_STATIC_SITES }}
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - uses: azure/login@v1
+      with:
+        creds: ${{ secrets.creds }}
+
+    - name: Upload to blob storage
+      id: upload
+      uses: azure/CLI@v1
+      with:
+        inlineScript: |
+          az storage blob upload \
+            --account-name zooniversestatic \
+            --content-cache-control 'public, max-age=60' \
+            --container-name '$web' \
+            --name 'data.galaxyzoo.org/index.html' \
+            --file './index.html'
+          rm ./index.html
+          az storage blob upload-batch \
+            --account-name zooniversestatic \
+            --content-cache-control 'public, immutable, max-age=600' \
+            --destination '$web/data.galaxyzoo.org' \
+            --source ./
 
   slack_notification:
     name: Send Slack notification


### PR DESCRIPTION
It was useful to test the remote reusable workflows, but this doesn't need a build step at all and therefore can just use it's own simple, local "deploy to blob storage" workflow. Using a 600 second max-age for all the files that aren't index.html in case something changes in this non-single-page-app-site.