### PR TITLE
Use az credentials secret

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -14,7 +14,7 @@ jobs:
 
     - uses: azure/login@v1
       with:
-        creds: ${{ secrets.creds }}
+        creds: ${{ secrets.AZURE_STATIC_SITES }}
 
     - name: Upload to blob storage
       id: upload


### PR DESCRIPTION
If not using a reusable workflow, point directly at the org secret to login to Azure.