### PR TITLE
add GZ2 Zenodo link to data page

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -33,6 +33,7 @@
 		    			<a data-scroll-nav="7">Galaxy Zoo 2</a>
 		    			<ul class="sub-nav">
 		    				<li><a data-scroll-nav="8">Full Catalog</a></li>
+						<li><a data-scroll-nav="21">Images</a></li>
 		    				<li><a data-scroll-nav="9">Bar Lengths</a></li>
 		    				<li><a data-scroll-nav="10">Dust-Lane Spheroidal Galaxies</a></li>
 		    			</ul>
@@ -559,6 +560,13 @@
 						<h3>SDSS Skyserver</h3>
 						<p>For any object in SDSS DR10, you can access its Galaxy Zoo or Galaxy Zoo 2 classifications (if present) by using the <a href="http://skyserver.sdss3.org/public/en/tools/explore/">"Explore"</a> tool. Just click the "Galaxy Zoo" link under "Imaging Summary" in the left-hand sidebar (<a href="http://skyserver.sdss3.org/public/en/tools/explore/galaxyzoo.aspx?id=1237668296598749280&spec=2947691243863304192&apid=apogee.n.s.s3.4128.2M13102744+1826172">example here</a>).
 
+					</div>
+
+					<div data-scroll-index="21">
+						<h2>Images</h2>
+						<p>The GZ2 images are <a href="https://zenodo.org/record/3565489#.Y3vFKS-l0eY">available for download on Zenodo.</a></p>
+						<br />
+						
 					</div>
 
 					<div data-scroll-index="9">


### PR DESCRIPTION
Should just be the addition of 1 menu element and 1 content div. It puts the indexing out of order, however -- will fix if needed/desired.