### PR TITLE
Update deploy action to overwrite

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -24,6 +24,7 @@ jobs:
           az storage blob upload \
             --account-name zooniversestatic \
             --content-cache-control 'public, max-age=60' \
+            --overwrite \
             --container-name '$web' \
             --name 'data.galaxyzoo.org/index.html' \
             --file './public/index.html'
@@ -31,6 +32,7 @@ jobs:
           az storage blob upload-batch \
             --account-name zooniversestatic \
             --content-cache-control 'public, immutable, max-age=600' \
+            --overwrite \
             --destination '$web/data.galaxyzoo.org' \
             --source ./public
 


### PR DESCRIPTION
Deploys are failing because the action is pulling a newer version of the az CLI than expected. New versions now require the `--overwrite` flag to be included to match previous versions' default behavior. See PRs 14-18 in the ci-cd repo for details.